### PR TITLE
Add Supabase client abstraction

### DIFF
--- a/lib/core/data/clients/supabase/supabase_client_impl.dart
+++ b/lib/core/data/clients/supabase/supabase_client_impl.dart
@@ -1,0 +1,30 @@
+import 'package:injectable/injectable.dart';
+import 'package:supabase_flutter/supabase_flutter.dart';
+
+import 'supabase_client_interface.dart';
+
+@Singleton(as: ISupabaseClient)
+class SupabaseClientImpl implements ISupabaseClient {
+  final GoTrueClient _auth;
+
+  SupabaseClientImpl() : _auth = Supabase.instance.client.auth;
+
+  @override
+  Future<AuthResponse> signInWithIdToken({
+    required OAuthProvider provider,
+    required String idToken,
+    required String accessToken,
+  }) {
+    return _auth.signInWithIdToken(
+      provider: provider,
+      idToken: idToken,
+      accessToken: accessToken,
+    );
+  }
+
+  @override
+  User? get currentUser => _auth.currentUser;
+
+  @override
+  Future<void> signOut() => _auth.signOut();
+}

--- a/lib/core/data/clients/supabase/supabase_client_interface.dart
+++ b/lib/core/data/clients/supabase/supabase_client_interface.dart
@@ -1,0 +1,13 @@
+import "package:supabase_flutter/supabase_flutter.dart";
+
+abstract class ISupabaseClient {
+  Future<AuthResponse> signInWithIdToken({
+    required OAuthProvider provider,
+    required String idToken,
+    required String accessToken,
+  });
+
+  User? get currentUser;
+
+  Future<void> signOut();
+}

--- a/lib/core/di/dependency_injection.config.dart
+++ b/lib/core/di/dependency_injection.config.dart
@@ -30,6 +30,8 @@ import '../data/clients/shared_preferences/local_storage_interface.dart'
     as _i824;
 import '../data/clients/shared_preferences/shared_preferences_service.dart'
     as _i755;
+import '../data/clients/supabase/supabase_client_interface.dart' as _i900;
+import '../data/clients/supabase/supabase_client_impl.dart' as _i901;
 import 'dependency_injection.dart' as _i9;
 
 extension GetItInjectableX on _i174.GetIt {
@@ -46,10 +48,14 @@ extension GetItInjectableX on _i174.GetIt {
     );
     gh.factory<_i361.Dio>(() => registerModule.dio);
     gh.factory<_i824.ILocalStorage>(() => _i755.SharedPreferencesService());
-    gh.factory<_i655.AuthDatasource>(() => _i275.AuthDatasourceImpl());
+    gh.factory<_i655.AuthDatasource>(
+        () => _i275.AuthDatasourceImpl(
+              supabaseClient: gh<_i900.ISupabaseClient>(),
+            ));
     gh.singleton<_i777.ClientHttp>(
       () => _i14.DioClientHttpImpl(dio: gh<_i361.Dio>()),
     );
+    gh.singleton<_i900.ISupabaseClient>(() => _i901.SupabaseClientImpl());
     gh.factory<_i779.AuthRepository>(
       () =>
           _i817.AuthRepositoryImpl(authDatasource: gh<_i655.AuthDatasource>()),

--- a/lib/modules/auth/data/datasources/auth_datasource_impl.dart
+++ b/lib/modules/auth/data/datasources/auth_datasource_impl.dart
@@ -7,9 +7,14 @@ import 'package:school_planting/modules/auth/data/adapters/user_adapter.dart';
 import 'package:school_planting/modules/auth/data/datasources/auth_datasource.dart';
 import 'package:school_planting/modules/auth/domain/entities/user_entity.dart';
 import 'package:supabase_flutter/supabase_flutter.dart';
+import 'package:school_planting/core/data/clients/supabase/supabase_client_interface.dart';
 
 @Injectable(as: AuthDatasource)
 class AuthDatasourceImpl implements AuthDatasource {
+  final ISupabaseClient _supabaseClient;
+
+  AuthDatasourceImpl({required ISupabaseClient supabaseClient})
+      : _supabaseClient = supabaseClient;
   @override
   Future<UserEntity> loginWithGoogleAccount() async {
     try {
@@ -31,7 +36,7 @@ class AuthDatasourceImpl implements AuthDatasource {
 
       final idToken = googleUser.authentication.idToken;
 
-      final result = await Supabase.instance.client.auth.signInWithIdToken(
+      final result = await _supabaseClient.signInWithIdToken(
         provider: OAuthProvider.google,
         idToken: idToken!,
         accessToken: accessToken,
@@ -53,7 +58,7 @@ class AuthDatasourceImpl implements AuthDatasource {
 
   @override
   Future<UserEntity?> autoLogin() async {
-    final user = Supabase.instance.client.auth.currentUser;
+    final user = _supabaseClient.currentUser;
 
     if (user == null) {
       return null;
@@ -68,6 +73,6 @@ class AuthDatasourceImpl implements AuthDatasource {
 
   @override
   Future<void> logout() async {
-    await Supabase.instance.client.auth.signOut();
+    await _supabaseClient.signOut();
   }
 }


### PR DESCRIPTION
## Summary
- add Supabase client interface and implementation
- wire Supabase client into auth datasource via dependency injection

## Testing
- `dart --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686d52fea2608322b6be384b61f4d286