### PR TITLE
Add planting feature

### DIFF
--- a/lib/core/di/dependency_injection.dart
+++ b/lib/core/di/dependency_injection.dart
@@ -7,6 +7,12 @@ import 'package:school_planting/core/di/dependency_injection.config.dart';
 import 'package:school_planting/core/domain/entities/app_global.dart';
 import 'package:school_planting/core/domain/entities/usecase.dart';
 import 'package:school_planting/modules/auth/domain/usecases/auto_login.dart';
+import 'package:school_planting/modules/planting/data/datasources/planting_datasource.dart';
+import 'package:school_planting/modules/planting/data/datasources/planting_datasource_impl.dart';
+import 'package:school_planting/modules/planting/data/repositories/planting_repository_impl.dart';
+import 'package:school_planting/modules/planting/domain/repositories/planting_repository.dart';
+import 'package:school_planting/modules/planting/domain/usecases/create_planting_usecase.dart';
+import 'package:school_planting/modules/planting/presentation/controller/planting_bloc.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
 final GetIt getIt = GetIt.instance;
@@ -20,6 +26,15 @@ Future<void> configureDependencies() async {
   _initAppGlobal();
 
   await getIt.init();
+
+  getIt
+    ..registerFactory<PlantingDatasource>(() => PlantingDatasourceImpl())
+    ..registerFactory<PlantingRepository>(
+        () => PlantingRepositoryImpl(datasource: getIt<PlantingDatasource>()))
+    ..registerFactory<CreatePlantingUseCase>(
+        () => CreatePlantingUseCase(repository: getIt<PlantingRepository>()))
+    ..registerFactory<PlantingBloc>(
+        () => PlantingBloc(createPlantingUseCase: getIt<CreatePlantingUseCase>()));
 
   await _tryAutoLogin();
 }

--- a/lib/core/domain/entities/named_routes.dart
+++ b/lib/core/domain/entities/named_routes.dart
@@ -1,7 +1,8 @@
 enum NamedRoutes {
   splash('/'),
   auth('/auth'),
-  home('/home');
+  home('/home'),
+  planting('/planting');
 
   final String route;
   const NamedRoutes(this.route);

--- a/lib/core/routes/app_routes.dart
+++ b/lib/core/routes/app_routes.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:school_planting/modules/auth/presentation/auth_page.dart';
 import 'package:school_planting/modules/home/presentation/home_page.dart';
 import 'package:school_planting/modules/splash/presentation/splash_page.dart';
+import 'package:school_planting/modules/planting/presentation/planting_page.dart';
 
 import '../domain/entities/named_routes.dart';
 import 'domain/entities/custom_transition.dart';
@@ -17,6 +18,7 @@ class CustomNavigator {
       NamedRoutes.splash.route: (BuildContext context) => const SplashPage(),
       NamedRoutes.auth.route: (BuildContext context) => const AuthPage(),
       NamedRoutes.home.route: (BuildContext context) => const HomePage(),
+      NamedRoutes.planting.route: (BuildContext context) => const PlantingPage(),
     };
 
     final WidgetBuilder? builder = appRoutes[settings.name];

--- a/lib/modules/home/presentation/home_page.dart
+++ b/lib/modules/home/presentation/home_page.dart
@@ -3,6 +3,7 @@ import 'package:school_planting/core/constants/constants.dart';
 import 'package:school_planting/modules/home/presentation/widgets/card_user_widget.dart';
 import 'package:school_planting/modules/home/presentation/widgets/map_planting_widget.dart';
 import 'package:school_planting/shared/themes/app_theme_constants.dart';
+import 'package:school_planting/core/domain/entities/named_routes.dart';
 
 class HomePage extends StatefulWidget {
   const HomePage({super.key});
@@ -25,7 +26,9 @@ class _HomePageState extends State<HomePage> {
           ),
           padding: const EdgeInsets.symmetric(horizontal: 20, vertical: 10),
         ),
-        onPressed: () {},
+        onPressed: () {
+          Navigator.pushNamed(context, NamedRoutes.planting.route);
+        },
         child: Row(
           mainAxisSize: MainAxisSize.min,
           children: [

--- a/lib/modules/planting/data/datasources/planting_datasource.dart
+++ b/lib/modules/planting/data/datasources/planting_datasource.dart
@@ -1,0 +1,10 @@
+import 'dart:io';
+
+abstract class PlantingDatasource {
+  Future<void> createPlanting({
+    required String userId,
+    required String description,
+    required File image,
+    required String imageName,
+  });
+}

--- a/lib/modules/planting/data/datasources/planting_datasource_impl.dart
+++ b/lib/modules/planting/data/datasources/planting_datasource_impl.dart
@@ -1,0 +1,32 @@
+import 'dart:io';
+
+import 'package:injectable/injectable.dart';
+import 'package:supabase_flutter/supabase_flutter.dart';
+
+import 'planting_datasource.dart';
+
+@LazySingleton(as: PlantingDatasource)
+class PlantingDatasourceImpl implements PlantingDatasource {
+  final SupabaseClient _client;
+
+  PlantingDatasourceImpl() : _client = Supabase.instance.client;
+
+  @override
+  Future<void> createPlanting({
+    required String userId,
+    required String description,
+    required File image,
+    required String imageName,
+  }) async {
+    await _client.storage.from('plantings').upload(
+      imageName,
+      image,
+    );
+
+    await _client.from('user_plantings').insert({
+      'user_id': userId,
+      'description': description,
+      'image_name': imageName,
+    });
+  }
+}

--- a/lib/modules/planting/data/repositories/planting_repository_impl.dart
+++ b/lib/modules/planting/data/repositories/planting_repository_impl.dart
@@ -1,0 +1,37 @@
+import 'dart:io';
+
+import 'package:injectable/injectable.dart';
+import 'package:school_planting/core/domain/entities/either_of.dart';
+import 'package:school_planting/core/domain/entities/failure.dart';
+import 'package:school_planting/modules/planting/data/datasources/planting_datasource.dart';
+import 'package:school_planting/modules/planting/domain/entities/planting_entity.dart';
+import 'package:school_planting/modules/planting/domain/exceptions/planting_exception.dart';
+import 'package:school_planting/modules/planting/domain/repositories/planting_repository.dart';
+
+@Injectable(as: PlantingRepository)
+class PlantingRepositoryImpl implements PlantingRepository {
+  final PlantingDatasource _datasource;
+
+  PlantingRepositoryImpl({required PlantingDatasource datasource})
+      : _datasource = datasource;
+
+  @override
+  Future<EitherOf<AppFailure, VoidSuccess>> createPlanting(
+    PlantingEntity planting,
+    File image,
+  ) async {
+    try {
+      await _datasource.createPlanting(
+        userId: planting.userId,
+        description: planting.description,
+        image: image,
+        imageName: planting.imageName,
+      );
+      return resolve(const VoidSuccess());
+    } on AppFailure catch (e) {
+      return reject(e);
+    } catch (e) {
+      return reject(PlantingException(e.toString()));
+    }
+  }
+}

--- a/lib/modules/planting/domain/entities/planting_entity.dart
+++ b/lib/modules/planting/domain/entities/planting_entity.dart
@@ -1,0 +1,11 @@
+class PlantingEntity {
+  final String description;
+  final String imageName;
+  final String userId;
+
+  PlantingEntity({
+    required this.description,
+    required this.imageName,
+    required this.userId,
+  });
+}

--- a/lib/modules/planting/domain/exceptions/planting_exception.dart
+++ b/lib/modules/planting/domain/exceptions/planting_exception.dart
@@ -1,0 +1,5 @@
+import 'package:school_planting/core/domain/entities/failure.dart';
+
+class PlantingException extends AppFailure {
+  PlantingException(super.message);
+}

--- a/lib/modules/planting/domain/repositories/planting_repository.dart
+++ b/lib/modules/planting/domain/repositories/planting_repository.dart
@@ -1,0 +1,12 @@
+import 'dart:io';
+
+import 'package:school_planting/core/domain/entities/either_of.dart';
+import 'package:school_planting/core/domain/entities/failure.dart';
+import 'package:school_planting/modules/planting/domain/entities/planting_entity.dart';
+
+abstract class PlantingRepository {
+  Future<EitherOf<AppFailure, VoidSuccess>> createPlanting(
+    PlantingEntity planting,
+    File image,
+  );
+}

--- a/lib/modules/planting/domain/usecases/create_planting_usecase.dart
+++ b/lib/modules/planting/domain/usecases/create_planting_usecase.dart
@@ -1,0 +1,28 @@
+import 'dart:io';
+
+import 'package:injectable/injectable.dart';
+import 'package:school_planting/core/domain/entities/either_of.dart';
+import 'package:school_planting/core/domain/entities/failure.dart';
+import 'package:school_planting/core/domain/entities/usecase.dart';
+import 'package:school_planting/modules/planting/domain/entities/planting_entity.dart';
+import 'package:school_planting/modules/planting/domain/repositories/planting_repository.dart';
+
+@injectable
+class CreatePlantingUseCase implements UseCase<VoidSuccess, CreatePlantingParams> {
+  final PlantingRepository _repository;
+
+  CreatePlantingUseCase({required PlantingRepository repository})
+      : _repository = repository;
+
+  @override
+  Future<EitherOf<AppFailure, VoidSuccess>> call(CreatePlantingParams params) {
+    return _repository.createPlanting(params.entity, params.image);
+  }
+}
+
+class CreatePlantingParams {
+  final PlantingEntity entity;
+  final File image;
+
+  const CreatePlantingParams({required this.entity, required this.image});
+}

--- a/lib/modules/planting/presentation/controller/planting_bloc.dart
+++ b/lib/modules/planting/presentation/controller/planting_bloc.dart
@@ -1,0 +1,32 @@
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:injectable/injectable.dart';
+import 'package:school_planting/modules/planting/domain/usecases/create_planting_usecase.dart';
+import 'package:school_planting/modules/planting/presentation/controller/planting_events.dart';
+import 'package:school_planting/modules/planting/presentation/controller/planting_states.dart';
+
+@injectable
+class PlantingBloc extends Bloc<PlantingEvents, PlantingStates> {
+  final CreatePlantingUseCase _createUseCase;
+
+  PlantingBloc({required CreatePlantingUseCase createPlantingUseCase})
+      : _createUseCase = createPlantingUseCase,
+        super(PlantingInitialState()) {
+    on<CreatePlantingEvent>(_onCreatePlanting);
+  }
+
+  Future<void> _onCreatePlanting(
+    CreatePlantingEvent event,
+    Emitter<PlantingStates> emit,
+  ) async {
+    emit(state.loading());
+
+    final result = await _createUseCase(
+      CreatePlantingParams(entity: event.entity, image: event.image),
+    );
+
+    result.get(
+      (failure) => emit(state.failure(failure.message)),
+      (_) => emit(state.success()),
+    );
+  }
+}

--- a/lib/modules/planting/presentation/controller/planting_events.dart
+++ b/lib/modules/planting/presentation/controller/planting_events.dart
@@ -1,0 +1,12 @@
+import 'dart:io';
+
+import 'package:school_planting/modules/planting/domain/entities/planting_entity.dart';
+
+abstract class PlantingEvents {}
+
+class CreatePlantingEvent extends PlantingEvents {
+  final PlantingEntity entity;
+  final File image;
+
+  CreatePlantingEvent({required this.entity, required this.image});
+}

--- a/lib/modules/planting/presentation/controller/planting_states.dart
+++ b/lib/modules/planting/presentation/controller/planting_states.dart
@@ -1,0 +1,16 @@
+abstract class PlantingStates {
+  PlantingLoadingState loading() => PlantingLoadingState();
+  PlantingSuccessState success() => PlantingSuccessState();
+  PlantingFailureState failure(String message) => PlantingFailureState(message);
+}
+
+class PlantingInitialState extends PlantingStates {}
+
+class PlantingLoadingState extends PlantingStates {}
+
+class PlantingSuccessState extends PlantingStates {}
+
+class PlantingFailureState extends PlantingStates {
+  final String message;
+  PlantingFailureState(this.message);
+}

--- a/lib/modules/planting/presentation/planting_page.dart
+++ b/lib/modules/planting/presentation/planting_page.dart
@@ -1,0 +1,153 @@
+import 'dart:io';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:image_picker/image_picker.dart';
+import 'package:uuid/uuid.dart';
+
+import 'package:school_planting/core/constants/constants.dart';
+import 'package:school_planting/core/di/dependency_injection.dart';
+import 'package:school_planting/core/domain/entities/app_global.dart';
+import 'package:school_planting/modules/planting/domain/entities/planting_entity.dart';
+import 'package:school_planting/modules/planting/presentation/controller/planting_bloc.dart';
+import 'package:school_planting/modules/planting/presentation/controller/planting_events.dart';
+import 'package:school_planting/modules/planting/presentation/controller/planting_states.dart';
+import 'package:school_planting/shared/components/app_circular_indicator_widget.dart';
+import 'package:school_planting/shared/components/app_snackbar.dart';
+import 'package:school_planting/shared/components/custom_app_bar.dart';
+import 'package:school_planting/shared/components/custom_button.dart';
+import 'package:school_planting/shared/components/text_form_field.dart';
+import 'package:school_planting/shared/themes/app_theme_constants.dart';
+
+class PlantingPage extends StatefulWidget {
+  const PlantingPage({super.key});
+
+  @override
+  State<PlantingPage> createState() => _PlantingPageState();
+}
+
+class _PlantingPageState extends State<PlantingPage> {
+  final PlantingBloc _bloc = getIt<PlantingBloc>();
+  final TextEditingController _descController = TextEditingController();
+  final ImagePicker _picker = ImagePicker();
+  File? _image;
+
+  @override
+  void dispose() {
+    _descController.dispose();
+    super.dispose();
+  }
+
+  Future<void> _takePhoto() async {
+    final XFile? picked = await _picker.pickImage(source: ImageSource.camera);
+    if (picked != null) {
+      setState(() => _image = File(picked.path));
+    }
+  }
+
+  void _save() {
+    if (_image == null) {
+      showAppSnackbar(
+        context,
+        title: 'Erro',
+        message: 'Tire uma foto da planta',
+        type: TypeSnack.error,
+      );
+      return;
+    }
+
+    final String uuid = const Uuid().v4();
+
+    final entity = PlantingEntity(
+      description: _descController.text,
+      imageName: uuid,
+      userId: AppGlobal.instance.user!.id.value,
+    );
+
+    _bloc.add(CreatePlantingEvent(entity: entity, image: _image!));
+  }
+
+  Widget _handleButtonState(PlantingStates state) {
+    if (state is PlantingLoadingState) {
+      return const AppCircularIndicatorWidget(size: 20);
+    }
+
+    return Text(
+      'Salvar',
+      style: context.textTheme.bodyLarge?.copyWith(fontWeight: FontWeight.bold),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: CustomAppBar(title: const Text('Nova plantação')),
+      body: BlocListener<PlantingBloc, PlantingStates>(
+        bloc: _bloc,
+        listener: (context, state) {
+          if (state is PlantingSuccessState) {
+            showAppSnackbar(
+              context,
+              title: 'Sucesso',
+              message: 'Plantação registrada',
+              type: TypeSnack.success,
+            );
+            Navigator.pop(context);
+          }
+          if (state is PlantingFailureState) {
+            showAppSnackbar(
+              context,
+              title: 'Erro',
+              message: state.message,
+              type: TypeSnack.error,
+            );
+          }
+        },
+        child: Padding(
+          padding: const EdgeInsets.all(AppThemeConstants.padding),
+          child: Column(
+            children: [
+              AppTextFormField(
+                controller: _descController,
+                hint: 'Descrição da planta',
+              ),
+              const SizedBox(height: 20),
+              GestureDetector(
+                onTap: _takePhoto,
+                child: Container(
+                  height: 200,
+                  width: double.infinity,
+                  decoration: BoxDecoration(
+                    color: Colors.grey.shade300,
+                    borderRadius: BorderRadius.circular(
+                      AppThemeConstants.mediumBorderRadius,
+                    ),
+                  ),
+                  child: _image != null
+                      ? ClipRRect(
+                          borderRadius: BorderRadius.circular(
+                            AppThemeConstants.mediumBorderRadius,
+                          ),
+                          child: Image.file(_image!, fit: BoxFit.cover),
+                        )
+                      : Icon(Icons.camera_alt, size: 50, color: Colors.grey.shade700),
+                ),
+              ),
+              const Spacer(),
+              BlocBuilder<PlantingBloc, PlantingStates>(
+                bloc: _bloc,
+                builder: (context, state) {
+                  return AppCustomButton(
+                    expands: true,
+                    onPressed: _save,
+                    label: _handleButtonState(state),
+                  );
+                },
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -47,6 +47,8 @@ dependencies:
   lottie: ^3.3.1
   google_maps_flutter: ^2.12.3
   geolocator: ^14.0.2
+  image_picker: ^1.0.7
+  uuid: ^4.3.3
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
## Summary
- add new planting feature
- navigate to PlantingPage from home
- store planting with photo and description using Supabase
- wire up bloc, datasource, repository, usecase
- register dependencies
- add image_picker and uuid packages

## Testing
- `dart format -o none --set-exit-if-changed lib/modules/planting/presentation/planting_page.dart` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686d5a17056083229e52d315e99fd568