### PR TITLE
Inject Supabase client into Planting datasource

### DIFF
--- a/lib/core/data/clients/supabase/supabase_client_impl.dart
+++ b/lib/core/data/clients/supabase/supabase_client_impl.dart
@@ -1,3 +1,5 @@
+import 'dart:io';
+
 import 'package:injectable/injectable.dart';
 import 'package:supabase_flutter/supabase_flutter.dart';
 
@@ -6,8 +8,11 @@ import 'supabase_client_interface.dart';
 @Singleton(as: ISupabaseClient)
 class SupabaseClientImpl implements ISupabaseClient {
   final GoTrueClient _auth;
+  final SupabaseClient _client;
 
-  SupabaseClientImpl() : _auth = Supabase.instance.client.auth;
+  SupabaseClientImpl()
+      : _client = Supabase.instance.client,
+        _auth = Supabase.instance.client.auth;
 
   @override
   Future<AuthResponse> signInWithIdToken({
@@ -27,4 +32,21 @@ class SupabaseClientImpl implements ISupabaseClient {
 
   @override
   Future<void> signOut() => _auth.signOut();
+
+  @override
+  Future<void> uploadFile({
+    required String bucket,
+    required String path,
+    required File file,
+  }) async {
+    await _client.storage.from(bucket).upload(path, file);
+  }
+
+  @override
+  Future<void> insert({
+    required String table,
+    required Map<String, dynamic> data,
+  }) async {
+    await _client.from(table).insert(data);
+  }
 }

--- a/lib/core/data/clients/supabase/supabase_client_interface.dart
+++ b/lib/core/data/clients/supabase/supabase_client_interface.dart
@@ -1,3 +1,5 @@
+import "dart:io";
+
 import "package:supabase_flutter/supabase_flutter.dart";
 
 abstract class ISupabaseClient {
@@ -10,4 +12,15 @@ abstract class ISupabaseClient {
   User? get currentUser;
 
   Future<void> signOut();
+
+  Future<void> uploadFile({
+    required String bucket,
+    required String path,
+    required File file,
+  });
+
+  Future<void> insert({
+    required String table,
+    required Map<String, dynamic> data,
+  });
 }

--- a/lib/core/di/dependency_injection.config.dart
+++ b/lib/core/di/dependency_injection.config.dart
@@ -59,7 +59,11 @@ extension GetItInjectableX on _i174.GetIt {
       preResolve: true,
     );
     gh.factory<_i361.Dio>(() => registerModule.dio);
-    gh.factory<_i155.PlantingDatasource>(() => _i64.PlantingDatasourceImpl());
+    gh.factory<_i155.PlantingDatasource>(
+      () => _i64.PlantingDatasourceImpl(
+        supabaseClient: gh<_i86.ISupabaseClient>(),
+      ),
+    );
     gh.factory<_i824.ILocalStorage>(() => _i755.SharedPreferencesService());
     gh.singleton<_i86.ISupabaseClient>(() => _i788.SupabaseClientImpl());
     gh.factory<_i91.PlantingRepository>(

--- a/lib/modules/planting/data/datasources/planting_datasource_impl.dart
+++ b/lib/modules/planting/data/datasources/planting_datasource_impl.dart
@@ -1,15 +1,16 @@
 import 'dart:io';
 
 import 'package:injectable/injectable.dart';
-import 'package:supabase_flutter/supabase_flutter.dart';
+import 'package:school_planting/core/data/clients/supabase/supabase_client_interface.dart';
 
 import 'planting_datasource.dart';
 
 @Injectable(as: PlantingDatasource)
 class PlantingDatasourceImpl implements PlantingDatasource {
-  final SupabaseClient _client;
+  final ISupabaseClient _client;
 
-  PlantingDatasourceImpl() : _client = Supabase.instance.client;
+  PlantingDatasourceImpl({required ISupabaseClient supabaseClient})
+      : _client = supabaseClient;
 
   @override
   Future<void> createPlanting({
@@ -20,16 +21,21 @@ class PlantingDatasourceImpl implements PlantingDatasource {
     required double latitude,
     required double longitude,
   }) async {
-    await _client.storage
-        .from('escolaverdebucket')
-        .upload('private/$imageName', image);
+    await _client.uploadFile(
+      bucket: 'escolaverdebucket',
+      path: 'private/$imageName',
+      file: image,
+    );
 
-    await _client.from('user_plantings').insert({
-      'user_id': userId,
-      'description': description,
-      'image_url': imageName,
-      'lat': latitude,
-      'long': longitude,
-    });
+    await _client.insert(
+      table: 'user_plantings',
+      data: {
+        'user_id': userId,
+        'description': description,
+        'image_url': imageName,
+        'lat': latitude,
+        'long': longitude,
+      },
+    );
   }
 }


### PR DESCRIPTION
## Summary
- allow injection of the Supabase client to `PlantingDatasourceImpl`
- extend `ISupabaseClient` with upload and insert helpers
- implement the new methods in `SupabaseClientImpl`
- wire new dependency in the generated DI config

## Testing
- `dart analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686d6d0809788322ba291e49e8a845bb