### PR TITLE
Add planting map markers

### DIFF
--- a/lib/modules/home/presentation/widgets/controller/map_planting_controller.dart
+++ b/lib/modules/home/presentation/widgets/controller/map_planting_controller.dart
@@ -1,13 +1,78 @@
 import 'dart:async';
+import 'dart:io';
+import 'dart:ui' as ui;
 
 import 'package:flutter/material.dart';
+import 'package:flutter/foundation.dart';
 import 'package:geolocator/geolocator.dart';
 import 'package:google_maps_flutter/google_maps_flutter.dart';
+import 'package:supabase_flutter/supabase_flutter.dart';
+
+class PlantingDetail {
+  final String description;
+  final String imageUrl;
+  final String userName;
+  final String userImageUrl;
+
+  PlantingDetail({
+    required this.description,
+    required this.imageUrl,
+    required this.userName,
+    required this.userImageUrl,
+  });
+}
 
 class MapPlantingController {
   final Set<Marker> markers = {};
   final Completer<GoogleMapController> googleMapController = Completer();
   StreamSubscription<Position>? _positionStream;
+
+  Future<BitmapDescriptor> _getCircularAvatarMarkerIcon(
+    String imageUrl, {
+    int size = 80,
+  }) async {
+    final HttpClient httpClient = HttpClient();
+    final HttpClientRequest request = await httpClient.getUrl(Uri.parse(imageUrl));
+    final HttpClientResponse response = await request.close();
+    final bytes = await consolidateHttpClientResponseBytes(response);
+
+    final ui.Codec codec = await ui.instantiateImageCodec(
+      bytes,
+      targetWidth: size,
+      targetHeight: size,
+    );
+    final ui.FrameInfo frame = await codec.getNextFrame();
+    final ui.Image avatarImage = frame.image;
+
+    final ui.PictureRecorder recorder = ui.PictureRecorder();
+    final Canvas canvas = Canvas(recorder);
+    final double radius = size / 2;
+
+    canvas.drawCircle(
+      Offset(radius, radius),
+      radius,
+      Paint()..color = Colors.white,
+    );
+
+    canvas.save();
+    canvas.clipPath(
+      Path()
+        ..addOval(
+          Rect.fromCircle(center: Offset(radius, radius), radius: radius - 4),
+        ),
+    );
+    canvas.drawImage(avatarImage, Offset.zero, Paint());
+    canvas.restore();
+
+    final ui.Image finalImage = await recorder.endRecording().toImage(
+      size,
+      size,
+    );
+    final ByteData? byteData = await finalImage.toByteData(
+      format: ui.ImageByteFormat.png,
+    );
+    return BitmapDescriptor.fromBytes(byteData!.buffer.asUint8List());
+  }
 
   // Future<BitmapDescriptor> _getCircularAvatarMarkerIcon(
   //   String imageUrl, {
@@ -109,6 +174,50 @@ class MapPlantingController {
 
           onUpdated(); // Notifica a View para atualizar
         });
+  }
+
+  Future<void> loadPlantings(
+    VoidCallback onUpdated,
+    void Function(PlantingDetail) onTap,
+  ) async {
+    final List<dynamic> data = await Supabase.instance.client
+        .from('user_plantings')
+        .select(
+            'description,image_url,lat,long,user_name,user_image_url')
+        .order('created_at');
+
+    for (final item in data) {
+      final double lat = (item['lat'] as num).toDouble();
+      final double long = (item['long'] as num).toDouble();
+      final String imageName = item['image_url'] as String;
+      final String url = Supabase.instance.client.storage
+          .from('escolaverdebucket')
+          .getPublicUrl('private/$imageName');
+
+      final BitmapDescriptor icon = await _getCircularAvatarMarkerIcon(url);
+
+      final detail = PlantingDetail(
+        description: item['description'] as String? ?? '',
+        imageUrl: url,
+        userName: item['user_name'] as String? ?? '',
+        userImageUrl: item['user_image_url'] as String? ?? '',
+      );
+
+      markers.add(
+        Marker(
+          markerId: MarkerId(imageName),
+          position: LatLng(lat, long),
+          icon: icon,
+          infoWindow: InfoWindow(
+            title: detail.userName,
+            snippet: detail.description,
+            onTap: () => onTap(detail),
+          ),
+        ),
+      );
+    }
+
+    onUpdated();
   }
 
   Future<void> moveCameraToCurrentLocation({double zoom = 18}) async {

--- a/lib/modules/home/presentation/widgets/map_planting_widget.dart
+++ b/lib/modules/home/presentation/widgets/map_planting_widget.dart
@@ -20,6 +20,51 @@ class _MapPlantingWidgetState extends State<MapPlantingWidget> {
   @override
   void initState() {
     super.initState();
+    _controller.startLocationUpdates(() => setState(() {}));
+    _controller.loadPlantings(() => setState(() {}), _showDetail);
+  }
+
+  void _showDetail(PlantingDetail detail) {
+    showModalBottomSheet(
+      context: context,
+      builder: (_) {
+        return Padding(
+          padding: const EdgeInsets.all(16),
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              ClipRRect(
+                borderRadius: BorderRadius.circular(8),
+                child: Image.network(
+                  detail.imageUrl,
+                  height: 180,
+                  width: double.infinity,
+                  fit: BoxFit.cover,
+                ),
+              ),
+              const SizedBox(height: 10),
+              Row(
+                children: [
+                  CircleAvatar(
+                    backgroundImage: NetworkImage(detail.userImageUrl),
+                  ),
+                  const SizedBox(width: 8),
+                  Expanded(
+                    child: Text(
+                      detail.userName,
+                      style: Theme.of(context).textTheme.titleMedium,
+                    ),
+                  ),
+                ],
+              ),
+              const SizedBox(height: 10),
+              Text(detail.description),
+            ],
+          ),
+        );
+      },
+    );
   }
 
   @override


### PR DESCRIPTION
## Summary
- display user plantings on map with custom markers
- show planting details in a bottom sheet when tapped

## Testing
- `dart analyze` *(fails: dart not installed)*

------
https://chatgpt.com/codex/tasks/task_e_686d70a9b78c83229b25f1c9e1be3b6b