### PR TITLE
Implement bloc-based planting loader for home map

### DIFF
--- a/lib/modules/home/data/datasources/map_planting_datasource.dart
+++ b/lib/modules/home/data/datasources/map_planting_datasource.dart
@@ -1,0 +1,5 @@
+import 'package:school_planting/modules/home/domain/entities/planting_detail_entity.dart';
+
+abstract class MapPlantingDatasource {
+  Future<List<PlantingDetailEntity>> fetchPlantings();
+}

--- a/lib/modules/home/data/datasources/map_planting_datasource_impl.dart
+++ b/lib/modules/home/data/datasources/map_planting_datasource_impl.dart
@@ -1,0 +1,34 @@
+import 'package:supabase_flutter/supabase_flutter.dart';
+import 'map_planting_datasource.dart';
+import 'package:school_planting/modules/home/domain/entities/planting_detail_entity.dart';
+
+class MapPlantingDatasourceImpl implements MapPlantingDatasource {
+  @override
+  Future<List<PlantingDetailEntity>> fetchPlantings() async {
+    final List<dynamic> data = await Supabase.instance.client
+        .from('user_plantings')
+        .select(
+            'description,image_url,lat,long,user_name,user_image_url')
+        .order('created_at');
+
+    final List<PlantingDetailEntity> result = [];
+    for (final item in data) {
+      final String imageName = item['image_url'] as String;
+      final String url = Supabase.instance.client.storage
+          .from('escolaverdebucket')
+          .getPublicUrl('private/$imageName');
+      result.add(
+        PlantingDetailEntity(
+          description: item['description'] as String? ?? '',
+          imageUrl: url,
+          userName: item['user_name'] as String? ?? '',
+          userImageUrl: item['user_image_url'] as String? ?? '',
+          latitude: (item['lat'] as num).toDouble(),
+          longitude: (item['long'] as num).toDouble(),
+        ),
+      );
+    }
+
+    return result;
+  }
+}

--- a/lib/modules/home/data/repositories/map_planting_repository_impl.dart
+++ b/lib/modules/home/data/repositories/map_planting_repository_impl.dart
@@ -1,0 +1,25 @@
+import 'package:school_planting/core/domain/entities/either_of.dart';
+import 'package:school_planting/core/domain/entities/failure.dart';
+import 'package:school_planting/modules/home/data/datasources/map_planting_datasource.dart';
+import 'package:school_planting/modules/home/domain/entities/planting_detail_entity.dart';
+import 'package:school_planting/modules/home/domain/exceptions/home_exception.dart';
+import 'package:school_planting/modules/home/domain/repositories/map_planting_repository.dart';
+
+class MapPlantingRepositoryImpl implements MapPlantingRepository {
+  final MapPlantingDatasource _datasource;
+
+  MapPlantingRepositoryImpl({required MapPlantingDatasource datasource})
+      : _datasource = datasource;
+
+  @override
+  Future<EitherOf<AppFailure, List<PlantingDetailEntity>>> getPlantings() async {
+    try {
+      final result = await _datasource.fetchPlantings();
+      return resolve(result);
+    } on AppFailure catch (e) {
+      return reject(e);
+    } catch (e) {
+      return reject(HomeException(e.toString()));
+    }
+  }
+}

--- a/lib/modules/home/domain/entities/planting_detail_entity.dart
+++ b/lib/modules/home/domain/entities/planting_detail_entity.dart
@@ -1,0 +1,17 @@
+class PlantingDetailEntity {
+  final String description;
+  final String imageUrl;
+  final String userName;
+  final String userImageUrl;
+  final double latitude;
+  final double longitude;
+
+  const PlantingDetailEntity({
+    required this.description,
+    required this.imageUrl,
+    required this.userName,
+    required this.userImageUrl,
+    required this.latitude,
+    required this.longitude,
+  });
+}

--- a/lib/modules/home/domain/exceptions/home_exception.dart
+++ b/lib/modules/home/domain/exceptions/home_exception.dart
@@ -1,0 +1,5 @@
+import 'package:school_planting/core/domain/entities/failure.dart';
+
+class HomeException extends AppFailure {
+  HomeException(super.message);
+}

--- a/lib/modules/home/domain/repositories/map_planting_repository.dart
+++ b/lib/modules/home/domain/repositories/map_planting_repository.dart
@@ -1,0 +1,7 @@
+import 'package:school_planting/core/domain/entities/either_of.dart';
+import 'package:school_planting/core/domain/entities/failure.dart';
+import 'package:school_planting/modules/home/domain/entities/planting_detail_entity.dart';
+
+abstract class MapPlantingRepository {
+  Future<EitherOf<AppFailure, List<PlantingDetailEntity>>> getPlantings();
+}

--- a/lib/modules/home/domain/usecases/get_plantings_usecase.dart
+++ b/lib/modules/home/domain/usecases/get_plantings_usecase.dart
@@ -1,0 +1,19 @@
+import 'package:school_planting/core/domain/entities/either_of.dart';
+import 'package:school_planting/core/domain/entities/failure.dart';
+import 'package:school_planting/core/domain/entities/usecase.dart';
+import 'package:school_planting/modules/home/domain/entities/planting_detail_entity.dart';
+import 'package:school_planting/modules/home/domain/repositories/map_planting_repository.dart';
+
+class GetPlantingsUseCase
+    implements UseCase<List<PlantingDetailEntity>, NoArgs> {
+  final MapPlantingRepository _repository;
+
+  GetPlantingsUseCase({required MapPlantingRepository repository})
+      : _repository = repository;
+
+  @override
+  Future<EitherOf<AppFailure, List<PlantingDetailEntity>>> call(
+      NoArgs args) {
+    return _repository.getPlantings();
+  }
+}

--- a/lib/modules/home/presentation/controller/plantings_bloc.dart
+++ b/lib/modules/home/presentation/controller/plantings_bloc.dart
@@ -1,0 +1,27 @@
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:school_planting/core/domain/entities/usecase.dart';
+import 'package:school_planting/modules/home/domain/usecases/get_plantings_usecase.dart';
+import 'plantings_events.dart';
+import 'plantings_states.dart';
+
+class PlantingsBloc extends Bloc<PlantingsEvents, PlantingsStates> {
+  final GetPlantingsUseCase _usecase;
+
+  PlantingsBloc({required GetPlantingsUseCase usecase})
+      : _usecase = usecase,
+        super(PlantingsInitialState()) {
+    on<LoadPlantingsEvent>(_onLoadPlantings);
+  }
+
+  Future<void> _onLoadPlantings(
+      LoadPlantingsEvent event, Emitter<PlantingsStates> emit) async {
+    emit(state.loading());
+
+    final result = await _usecase(const NoArgs());
+
+    result.get(
+      (failure) => emit(state.failure(failure.message)),
+      (data) => emit(state.success(data)),
+    );
+  }
+}

--- a/lib/modules/home/presentation/controller/plantings_events.dart
+++ b/lib/modules/home/presentation/controller/plantings_events.dart
@@ -1,0 +1,3 @@
+abstract class PlantingsEvents {}
+
+class LoadPlantingsEvent extends PlantingsEvents {}

--- a/lib/modules/home/presentation/controller/plantings_states.dart
+++ b/lib/modules/home/presentation/controller/plantings_states.dart
@@ -1,0 +1,22 @@
+import 'package:school_planting/modules/home/domain/entities/planting_detail_entity.dart';
+
+abstract class PlantingsStates {
+  PlantingsLoadingState loading() => PlantingsLoadingState();
+  PlantingsFailureState failure(String message) => PlantingsFailureState(message);
+  PlantingsSuccessState success(List<PlantingDetailEntity> plantings) =>
+      PlantingsSuccessState(plantings);
+}
+
+class PlantingsInitialState extends PlantingsStates {}
+
+class PlantingsLoadingState extends PlantingsStates {}
+
+class PlantingsFailureState extends PlantingsStates {
+  final String message;
+  PlantingsFailureState(this.message);
+}
+
+class PlantingsSuccessState extends PlantingsStates {
+  final List<PlantingDetailEntity> plantings;
+  PlantingsSuccessState(this.plantings);
+}

--- a/lib/modules/home/presentation/widgets/controller/map_planting_controller.dart
+++ b/lib/modules/home/presentation/widgets/controller/map_planting_controller.dart
@@ -6,21 +6,8 @@ import 'package:flutter/material.dart';
 import 'package:flutter/foundation.dart';
 import 'package:geolocator/geolocator.dart';
 import 'package:google_maps_flutter/google_maps_flutter.dart';
-import 'package:supabase_flutter/supabase_flutter.dart';
+import 'package:school_planting/modules/home/domain/entities/planting_detail_entity.dart';
 
-class PlantingDetail {
-  final String description;
-  final String imageUrl;
-  final String userName;
-  final String userImageUrl;
-
-  PlantingDetail({
-    required this.description,
-    required this.imageUrl,
-    required this.userName,
-    required this.userImageUrl,
-  });
-}
 
 class MapPlantingController {
   final Set<Marker> markers = {};
@@ -176,42 +163,24 @@ class MapPlantingController {
         });
   }
 
-  Future<void> loadPlantings(
+  Future<void> addPlantings(
+    List<PlantingDetailEntity> plantings,
     VoidCallback onUpdated,
-    void Function(PlantingDetail) onTap,
+    void Function(PlantingDetailEntity) onTap,
   ) async {
-    final List<dynamic> data = await Supabase.instance.client
-        .from('user_plantings')
-        .select(
-            'description,image_url,lat,long,user_name,user_image_url')
-        .order('created_at');
-
-    for (final item in data) {
-      final double lat = (item['lat'] as num).toDouble();
-      final double long = (item['long'] as num).toDouble();
-      final String imageName = item['image_url'] as String;
-      final String url = Supabase.instance.client.storage
-          .from('escolaverdebucket')
-          .getPublicUrl('private/$imageName');
-
-      final BitmapDescriptor icon = await _getCircularAvatarMarkerIcon(url);
-
-      final detail = PlantingDetail(
-        description: item['description'] as String? ?? '',
-        imageUrl: url,
-        userName: item['user_name'] as String? ?? '',
-        userImageUrl: item['user_image_url'] as String? ?? '',
-      );
+    for (final item in plantings) {
+      final BitmapDescriptor icon =
+          await _getCircularAvatarMarkerIcon(item.imageUrl);
 
       markers.add(
         Marker(
-          markerId: MarkerId(imageName),
-          position: LatLng(lat, long),
+          markerId: MarkerId(item.imageUrl),
+          position: LatLng(item.latitude, item.longitude),
           icon: icon,
           infoWindow: InfoWindow(
-            title: detail.userName,
-            snippet: detail.description,
-            onTap: () => onTap(detail),
+            title: item.userName,
+            snippet: item.description,
+            onTap: () => onTap(item),
           ),
         ),
       );


### PR DESCRIPTION
## Summary
- introduce clean architecture structure for home module
- add datasource, repository, usecase and bloc to load plantings
- refactor map controller and widget to use the new bloc

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_686d746883888322b0b5a6abcd145c55