### PR TITLE
Implement supabase client injection for map data

### DIFF
--- a/lib/core/data/clients/supabase/supabase_client_impl.dart
+++ b/lib/core/data/clients/supabase/supabase_client_impl.dart
@@ -49,4 +49,22 @@ class SupabaseClientImpl implements ISupabaseClient {
   }) async {
     await _client.from(table).insert(data);
   }
+
+  @override
+  Future<List<dynamic>> select({
+    required String table,
+    required String columns,
+    required String orderBy,
+  }) async {
+    final data = await _client.from(table).select(columns).order(orderBy);
+    return data;
+  }
+
+  @override
+  String getPublicUrl({
+    required String bucket,
+    required String path,
+  }) {
+    return _client.storage.from(bucket).getPublicUrl(path);
+  }
 }

--- a/lib/core/data/clients/supabase/supabase_client_interface.dart
+++ b/lib/core/data/clients/supabase/supabase_client_interface.dart
@@ -23,4 +23,15 @@ abstract class ISupabaseClient {
     required String table,
     required Map<String, dynamic> data,
   });
+
+  Future<List<dynamic>> select({
+    required String table,
+    required String columns,
+    required String orderBy,
+  });
+
+  String getPublicUrl({
+    required String bucket,
+    required String path,
+  });
 }

--- a/lib/core/di/dependency_injection.config.dart
+++ b/lib/core/di/dependency_injection.config.dart
@@ -72,7 +72,9 @@ extension GetItInjectableX on _i174.GetIt {
     gh.factory<_i361.Dio>(() => registerModule.dio);
     gh.factory<_i824.ILocalStorage>(() => _i755.SharedPreferencesService());
     gh.factory<_i711.MapPlantingDatasource>(
-      () => _i1020.MapPlantingDatasourceImpl(),
+      () => _i1020.MapPlantingDatasourceImpl(
+        supabaseClient: gh<_i86.ISupabaseClient>(),
+      ),
     );
     gh.singleton<_i86.ISupabaseClient>(() => _i788.SupabaseClientImpl());
     gh.factory<_i155.PlantingDatasource>(

--- a/lib/modules/home/data/datasources/map_planting_datasource_impl.dart
+++ b/lib/modules/home/data/datasources/map_planting_datasource_impl.dart
@@ -1,24 +1,31 @@
 import 'package:injectable/injectable.dart';
 import 'package:school_planting/modules/home/domain/entities/planting_detail_entity.dart';
-import 'package:supabase_flutter/supabase_flutter.dart';
+import 'package:school_planting/core/data/clients/supabase/supabase_client_interface.dart';
 
 import 'map_planting_datasource.dart';
 
 @Injectable(as: MapPlantingDatasource)
 class MapPlantingDatasourceImpl implements MapPlantingDatasource {
+  final ISupabaseClient _client;
+
+  MapPlantingDatasourceImpl({required ISupabaseClient supabaseClient})
+      : _client = supabaseClient;
+
   @override
   Future<List<PlantingDetailEntity>> fetchPlantings() async {
-    final List<dynamic> data = await Supabase.instance.client
-        .from('user_plantings')
-        .select('description,image_url,lat,long,user_name,user_image_url')
-        .order('created_at');
+    final List<dynamic> data = await _client.select(
+      table: 'user_plantings',
+      columns: 'description,image_url,lat,long,user_name,user_image_url',
+      orderBy: 'created_at',
+    );
 
     final List<PlantingDetailEntity> result = [];
     for (final item in data) {
       final String imageName = item['image_url'] as String;
-      final String url = Supabase.instance.client.storage
-          .from('escolaverdebucket')
-          .getPublicUrl('private/$imageName');
+      final String url = _client.getPublicUrl(
+        bucket: 'escolaverdebucket',
+        path: 'private/$imageName',
+      );
       result.add(
         PlantingDetailEntity(
           description: item['description'] as String? ?? '',


### PR DESCRIPTION
## Summary
- extend `ISupabaseClient` with select and public URL helpers
- support new methods in `SupabaseClientImpl`
- inject `ISupabaseClient` into `MapPlantingDatasourceImpl`
- wire new dependency in DI config

## Testing
- `dart format` *(fails: command not found)*
- `flutter --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686d76fa57a88322b4468287a44a8d12