### PR TITLE
Enable marker tap to zoom and show detail

### DIFF
--- a/lib/modules/home/presentation/widgets/controller/map_planting_controller.dart
+++ b/lib/modules/home/presentation/widgets/controller/map_planting_controller.dart
@@ -122,18 +122,29 @@ class MapPlantingController {
         item.imageUrl,
       );
 
-      markers.add(
-        Marker(
-          markerId: MarkerId(item.imageUrl),
-          position: LatLng(item.latitude, item.longitude),
-          icon: icon,
-          infoWindow: InfoWindow(
-            title: item.userName,
-            snippet: item.description,
-            onTap: () => onTap(item),
+        markers.add(
+          Marker(
+            markerId: MarkerId(item.imageUrl),
+            position: LatLng(item.latitude, item.longitude),
+            icon: icon,
+            onTap: () async {
+              final controller = await googleMapController.future;
+              controller.animateCamera(
+                CameraUpdate.newCameraPosition(
+                  CameraPosition(
+                    target: LatLng(item.latitude, item.longitude),
+                    zoom: 18,
+                  ),
+                ),
+              );
+              onTap(item);
+            },
+            infoWindow: InfoWindow(
+              title: item.userName,
+              snippet: item.description,
+            ),
           ),
-        ),
-      );
+        );
     }
 
     onUpdated();


### PR DESCRIPTION
## Summary
- show planting details when tapping a map marker
- zoom camera to the tapped marker

## Testing
- `dart --version` *(fails: command not found)*
- `flutter --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686d89c76d0c8322b5cd330827d7f793