### PR TITLE
Remove continuous location tracking

### DIFF
--- a/lib/modules/home/presentation/widgets/controller/map_planting_controller.dart
+++ b/lib/modules/home/presentation/widgets/controller/map_planting_controller.dart
@@ -11,7 +11,6 @@ import 'package:school_planting/modules/home/domain/entities/planting_detail_ent
 class MapPlantingController {
   final Set<Marker> markers = {};
   final Completer<GoogleMapController> googleMapController = Completer();
-  StreamSubscription<Position>? _positionStream;
 
   Future<BitmapDescriptor> _getCircularAvatarMarkerIcon(
     String imageUrl, {
@@ -80,21 +79,6 @@ class MapPlantingController {
     );
 
     onUpdated();
-
-    _positionStream =
-        Geolocator.getPositionStream(
-          locationSettings: const LocationSettings(
-            accuracy: LocationAccuracy.best,
-            distanceFilter: 0,
-          ),
-        ).listen((Position position) async {
-          final LatLng pos = LatLng(position.latitude, position.longitude);
-
-          final controller = await googleMapController.future;
-          controller.animateCamera(CameraUpdate.newLatLng(pos));
-
-          onUpdated(); // Notifica a View para atualizar
-        });
   }
 
   Future<void> addPlantings(
@@ -154,7 +138,5 @@ class MapPlantingController {
     );
   }
 
-  void dispose() {
-    _positionStream?.cancel();
-  }
+  void dispose() {}
 }

--- a/lib/modules/home/presentation/widgets/map_planting_widget.dart
+++ b/lib/modules/home/presentation/widgets/map_planting_widget.dart
@@ -31,7 +31,6 @@ class _MapPlantingWidgetState extends State<MapPlantingWidget> {
   void initState() {
     super.initState();
 
-    _controller.startLocationUpdates(() => setState(() {}));
     _platingBloc.add(LoadPlantingsEvent());
   }
 


### PR DESCRIPTION
## Summary
- stop continuously listening for location updates
- drop call to `startLocationUpdates()` when the map widget initializes

## Testing
- `flutter analyze` *(fails: flutter not installed)*

------
https://chatgpt.com/codex/tasks/task_e_686dcdf0b0d48322b5e3a205e69db657