### PR TITLE
Add MyPlantings list page

### DIFF
--- a/lib/core/di/dependency_injection.config.dart
+++ b/lib/core/di/dependency_injection.config.dart
@@ -49,6 +49,18 @@ import '../../modules/planting/domain/usecases/create_planting_usecase.dart'
     as _i1045;
 import '../../modules/planting/presentation/controller/planting_bloc.dart'
     as _i97;
+import '../../modules/my_plantings/data/datasources/my_plantings_datasource.dart'
+    as _i1100;
+import '../../modules/my_plantings/data/datasources/my_plantings_datasource_impl.dart'
+    as _i1101;
+import '../../modules/my_plantings/data/repositories/my_plantings_repository_impl.dart'
+    as _i1102;
+import '../../modules/my_plantings/domain/repositories/my_plantings_repository.dart'
+    as _i1103;
+import '../../modules/my_plantings/domain/usecases/get_my_plantings_usecase.dart'
+    as _i1104;
+import '../../modules/my_plantings/presentation/controller/my_plantings_bloc.dart'
+    as _i1105;
 import '../data/clients/http/client_http.dart' as _i777;
 import '../data/clients/http/dio_http_client_impl.dart' as _i14;
 import '../data/clients/shared_preferences/local_storage_interface.dart'
@@ -125,6 +137,24 @@ extension GetItInjectableX on _i174.GetIt {
       () => _i97.PlantingBloc(
         createPlantingUseCase: gh<_i1045.CreatePlantingUseCase>(),
       ),
+    );
+    gh.factory<_i1100.MyPlantingsDatasource>(
+      () => _i1101.MyPlantingsDatasourceImpl(
+        supabaseClient: gh<_i86.ISupabaseClient>(),
+      ),
+    );
+    gh.factory<_i1103.MyPlantingsRepository>(
+      () => _i1102.MyPlantingsRepositoryImpl(
+        datasource: gh<_i1100.MyPlantingsDatasource>(),
+      ),
+    );
+    gh.factory<_i1104.GetMyPlantingsUseCase>(
+      () => _i1104.GetMyPlantingsUseCase(
+        repository: gh<_i1103.MyPlantingsRepository>(),
+      ),
+    );
+    gh.factory<_i1105.MyPlantingsBloc>(
+      () => _i1105.MyPlantingsBloc(usecase: gh<_i1104.GetMyPlantingsUseCase>()),
     );
     gh.factory<_i51.AutoLoginUseCase>(
       () => _i51.AutoLoginUseCase(authRepository: gh<_i779.AuthRepository>()),

--- a/lib/core/domain/entities/named_routes.dart
+++ b/lib/core/domain/entities/named_routes.dart
@@ -2,7 +2,8 @@ enum NamedRoutes {
   splash('/'),
   auth('/auth'),
   home('/home'),
-  planting('/planting');
+  planting('/planting'),
+  myPlantings('/my-plantings');
 
   final String route;
   const NamedRoutes(this.route);

--- a/lib/core/routes/app_routes.dart
+++ b/lib/core/routes/app_routes.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:school_planting/modules/auth/presentation/auth_page.dart';
 import 'package:school_planting/modules/home/presentation/home_page.dart';
+import 'package:school_planting/modules/my_plantings/presentation/my_plantings_page.dart';
 import 'package:school_planting/modules/splash/presentation/splash_page.dart';
 import 'package:school_planting/modules/planting/presentation/planting_page.dart';
 
@@ -19,6 +20,7 @@ class CustomNavigator {
       NamedRoutes.auth.route: (BuildContext context) => const AuthPage(),
       NamedRoutes.home.route: (BuildContext context) => const HomePage(),
       NamedRoutes.planting.route: (BuildContext context) => const PlantingPage(),
+      NamedRoutes.myPlantings.route: (BuildContext context) => const MyPlantingsPage(),
     };
 
     final WidgetBuilder? builder = appRoutes[settings.name];

--- a/lib/modules/home/presentation/widgets/card_user_widget.dart
+++ b/lib/modules/home/presentation/widgets/card_user_widget.dart
@@ -116,6 +116,15 @@ class _CardUserWidgetState extends State<CardUserWidget> {
                   ),
                 ),
               ),
+              IconButton(
+                icon: const Icon(Icons.list, color: Colors.white),
+                onPressed: () {
+                  Navigator.pushNamed(
+                    context,
+                    NamedRoutes.myPlantings.route,
+                  );
+                },
+              ),
               BlocBuilder<AuthBloc, AuthStates>(
                 bloc: _authBloc,
                 builder: (context, states) {

--- a/lib/modules/my_plantings/data/datasources/my_plantings_datasource.dart
+++ b/lib/modules/my_plantings/data/datasources/my_plantings_datasource.dart
@@ -1,0 +1,5 @@
+import 'package:school_planting/modules/my_plantings/domain/entities/my_planting_entity.dart';
+
+abstract class MyPlantingsDatasource {
+  Future<List<MyPlantingEntity>> fetchMyPlantings(String userId);
+}

--- a/lib/modules/my_plantings/data/datasources/my_plantings_datasource_impl.dart
+++ b/lib/modules/my_plantings/data/datasources/my_plantings_datasource_impl.dart
@@ -1,0 +1,47 @@
+import 'package:injectable/injectable.dart';
+import 'package:school_planting/core/data/clients/supabase/supabase_client_interface.dart';
+import 'package:school_planting/modules/my_plantings/domain/entities/my_planting_entity.dart';
+
+import 'my_plantings_datasource.dart';
+
+@Injectable(as: MyPlantingsDatasource)
+class MyPlantingsDatasourceImpl implements MyPlantingsDatasource {
+  final ISupabaseClient _client;
+
+  MyPlantingsDatasourceImpl({required ISupabaseClient supabaseClient})
+      : _client = supabaseClient;
+
+  @override
+  Future<List<MyPlantingEntity>> fetchMyPlantings(String userId) async {
+    final List<dynamic> data = await _client.select(
+      table: 'user_plantings_with_userinfo',
+      columns:
+          'user_id,description,image_url,lat,long,user_name,photourl,created_at',
+    );
+
+    final List<MyPlantingEntity> result = [];
+
+    for (final item in data) {
+      if (item['user_id'] != userId) continue;
+
+      final String imageName = item['image_url'] as String;
+
+      final String url = await _client.getImageUrl(
+        bucket: 'escolaverdebucket',
+        path: 'private/$imageName',
+      );
+
+      result.add(
+        MyPlantingEntity(
+          description: item['description'] as String? ?? '',
+          imageUrl: url,
+          lat: (item['lat'] as num).toDouble(),
+          long: (item['long'] as num).toDouble(),
+          createdAt: DateTime.parse(item['created_at'] as String),
+        ),
+      );
+    }
+
+    return result;
+  }
+}

--- a/lib/modules/my_plantings/data/repositories/my_plantings_repository_impl.dart
+++ b/lib/modules/my_plantings/data/repositories/my_plantings_repository_impl.dart
@@ -1,0 +1,29 @@
+import 'package:injectable/injectable.dart';
+import 'package:school_planting/core/domain/entities/either_of.dart';
+import 'package:school_planting/core/domain/entities/failure.dart';
+import 'package:school_planting/core/domain/entities/app_global.dart';
+import 'package:school_planting/modules/my_plantings/data/datasources/my_plantings_datasource.dart';
+import 'package:school_planting/modules/my_plantings/domain/entities/my_planting_entity.dart';
+import 'package:school_planting/modules/my_plantings/domain/exceptions/my_plantings_exception.dart';
+import 'package:school_planting/modules/my_plantings/domain/repositories/my_plantings_repository.dart';
+
+@Injectable(as: MyPlantingsRepository)
+class MyPlantingsRepositoryImpl implements MyPlantingsRepository {
+  final MyPlantingsDatasource _datasource;
+
+  MyPlantingsRepositoryImpl({required MyPlantingsDatasource datasource})
+      : _datasource = datasource;
+
+  @override
+  Future<EitherOf<AppFailure, List<MyPlantingEntity>>> getMyPlantings() async {
+    try {
+      final userId = AppGlobal.instance.user?.id.value ?? '';
+      final result = await _datasource.fetchMyPlantings(userId);
+      return resolve(result);
+    } on AppFailure catch (e) {
+      return reject(e);
+    } catch (e) {
+      return reject(MyPlantingsException(e.toString()));
+    }
+  }
+}

--- a/lib/modules/my_plantings/domain/entities/my_planting_entity.dart
+++ b/lib/modules/my_plantings/domain/entities/my_planting_entity.dart
@@ -1,0 +1,15 @@
+class MyPlantingEntity {
+  final String description;
+  final String imageUrl;
+  final double lat;
+  final double long;
+  final DateTime createdAt;
+
+  const MyPlantingEntity({
+    required this.description,
+    required this.imageUrl,
+    required this.lat,
+    required this.long,
+    required this.createdAt,
+  });
+}

--- a/lib/modules/my_plantings/domain/exceptions/my_plantings_exception.dart
+++ b/lib/modules/my_plantings/domain/exceptions/my_plantings_exception.dart
@@ -1,0 +1,5 @@
+import 'package:school_planting/core/domain/entities/failure.dart';
+
+class MyPlantingsException extends AppFailure {
+  MyPlantingsException(super.message);
+}

--- a/lib/modules/my_plantings/domain/repositories/my_plantings_repository.dart
+++ b/lib/modules/my_plantings/domain/repositories/my_plantings_repository.dart
@@ -1,0 +1,7 @@
+import 'package:school_planting/core/domain/entities/either_of.dart';
+import 'package:school_planting/core/domain/entities/failure.dart';
+import 'package:school_planting/modules/my_plantings/domain/entities/my_planting_entity.dart';
+
+abstract class MyPlantingsRepository {
+  Future<EitherOf<AppFailure, List<MyPlantingEntity>>> getMyPlantings();
+}

--- a/lib/modules/my_plantings/domain/usecases/get_my_plantings_usecase.dart
+++ b/lib/modules/my_plantings/domain/usecases/get_my_plantings_usecase.dart
@@ -1,0 +1,20 @@
+import 'package:injectable/injectable.dart';
+import 'package:school_planting/core/domain/entities/either_of.dart';
+import 'package:school_planting/core/domain/entities/failure.dart';
+import 'package:school_planting/core/domain/entities/usecase.dart';
+import 'package:school_planting/modules/my_plantings/domain/entities/my_planting_entity.dart';
+import 'package:school_planting/modules/my_plantings/domain/repositories/my_plantings_repository.dart';
+
+@injectable
+class GetMyPlantingsUseCase
+    implements UseCase<List<MyPlantingEntity>, NoArgs> {
+  final MyPlantingsRepository _repository;
+
+  GetMyPlantingsUseCase({required MyPlantingsRepository repository})
+      : _repository = repository;
+
+  @override
+  Future<EitherOf<AppFailure, List<MyPlantingEntity>>> call(NoArgs args) {
+    return _repository.getMyPlantings();
+  }
+}

--- a/lib/modules/my_plantings/presentation/controller/my_plantings_bloc.dart
+++ b/lib/modules/my_plantings/presentation/controller/my_plantings_bloc.dart
@@ -1,0 +1,32 @@
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:injectable/injectable.dart';
+import 'package:school_planting/core/domain/entities/usecase.dart';
+import 'package:school_planting/modules/my_plantings/domain/usecases/get_my_plantings_usecase.dart';
+
+import 'my_plantings_events.dart';
+import 'my_plantings_states.dart';
+
+@injectable
+class MyPlantingsBloc extends Bloc<MyPlantingsEvents, MyPlantingsStates> {
+  final GetMyPlantingsUseCase _usecase;
+
+  MyPlantingsBloc({required GetMyPlantingsUseCase usecase})
+      : _usecase = usecase,
+        super(MyPlantingsInitialState()) {
+    on<LoadMyPlantingsEvent>(_onLoadMyPlantings);
+  }
+
+  Future<void> _onLoadMyPlantings(
+    LoadMyPlantingsEvent event,
+    Emitter<MyPlantingsStates> emit,
+  ) async {
+    emit(state.loading());
+
+    final result = await _usecase(const NoArgs());
+
+    result.get(
+      (failure) => emit(state.failure(failure.message)),
+      (data) => emit(state.success(data)),
+    );
+  }
+}

--- a/lib/modules/my_plantings/presentation/controller/my_plantings_events.dart
+++ b/lib/modules/my_plantings/presentation/controller/my_plantings_events.dart
@@ -1,0 +1,3 @@
+abstract class MyPlantingsEvents {}
+
+class LoadMyPlantingsEvent extends MyPlantingsEvents {}

--- a/lib/modules/my_plantings/presentation/controller/my_plantings_states.dart
+++ b/lib/modules/my_plantings/presentation/controller/my_plantings_states.dart
@@ -1,0 +1,22 @@
+import 'package:school_planting/modules/my_plantings/domain/entities/my_planting_entity.dart';
+
+abstract class MyPlantingsStates {
+  MyPlantingsLoadingState loading() => MyPlantingsLoadingState();
+  MyPlantingsFailureState failure(String message) => MyPlantingsFailureState(message);
+  MyPlantingsSuccessState success(List<MyPlantingEntity> plantings) =>
+      MyPlantingsSuccessState(plantings);
+}
+
+class MyPlantingsInitialState extends MyPlantingsStates {}
+
+class MyPlantingsLoadingState extends MyPlantingsStates {}
+
+class MyPlantingsFailureState extends MyPlantingsStates {
+  final String message;
+  MyPlantingsFailureState(this.message);
+}
+
+class MyPlantingsSuccessState extends MyPlantingsStates {
+  final List<MyPlantingEntity> plantings;
+  MyPlantingsSuccessState(this.plantings);
+}

--- a/lib/modules/my_plantings/presentation/my_plantings_page.dart
+++ b/lib/modules/my_plantings/presentation/my_plantings_page.dart
@@ -1,0 +1,123 @@
+import 'package:cached_network_image/cached_network_image.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:school_planting/core/constants/constants.dart';
+import 'package:school_planting/core/di/dependency_injection.dart';
+import 'package:school_planting/modules/home/presentation/widgets/dialog_view_image_widget.dart';
+import 'package:school_planting/modules/my_plantings/presentation/controller/my_plantings_bloc.dart';
+import 'package:school_planting/modules/my_plantings/presentation/controller/my_plantings_events.dart';
+import 'package:school_planting/modules/my_plantings/presentation/controller/my_plantings_states.dart';
+import 'package:school_planting/shared/components/app_circular_indicator_widget.dart';
+import 'package:school_planting/shared/components/app_snackbar.dart';
+import 'package:school_planting/shared/components/custom_app_bar.dart';
+import 'package:school_planting/shared/themes/app_theme_constants.dart';
+import 'package:school_planting/shared/utils/formatters.dart';
+
+class MyPlantingsPage extends StatefulWidget {
+  const MyPlantingsPage({super.key});
+
+  @override
+  State<MyPlantingsPage> createState() => _MyPlantingsPageState();
+}
+
+class _MyPlantingsPageState extends State<MyPlantingsPage> {
+  final MyPlantingsBloc _bloc = getIt<MyPlantingsBloc>();
+
+  @override
+  void initState() {
+    super.initState();
+
+    _bloc.add(LoadMyPlantingsEvent());
+  }
+
+  void _showImage(String url, String tag) {
+    Navigator.push(
+      context,
+      PageRouteBuilder(
+        opaque: false,
+        pageBuilder: (_, __, ___) => DialogViewImageWidget(path: url, tag: tag),
+      ),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: CustomAppBar(title: const Text('Minhas Plantações')),
+      body: BlocConsumer<MyPlantingsBloc, MyPlantingsStates>(
+        bloc: _bloc,
+        listener: (context, state) {
+          if (state is MyPlantingsFailureState) {
+            showAppSnackbar(
+              context,
+              title: 'Erro',
+              message: state.message,
+              type: TypeSnack.error,
+            );
+          }
+        },
+        builder: (context, state) {
+          if (state is MyPlantingsLoadingState) {
+            return const Center(child: AppCircularIndicatorWidget());
+          }
+
+          if (state is MyPlantingsSuccessState) {
+            if (state.plantings.isEmpty) {
+              return const Center(child: Text('Nenhuma plantação encontrada'));
+            }
+
+            return ListView.builder(
+              padding: const EdgeInsets.all(AppThemeConstants.padding),
+              itemCount: state.plantings.length,
+              itemBuilder: (context, index) {
+                final item = state.plantings[index];
+                final tag = item.imageUrl.split('/').last;
+
+                return Card(
+                  margin: const EdgeInsets.only(bottom: 10),
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      GestureDetector(
+                        onTap: () => _showImage(item.imageUrl, tag),
+                        child: Hero(
+                          tag: tag,
+                          child: CachedNetworkImage(
+                            imageUrl: item.imageUrl,
+                            height: context.screenHeight * 0.25,
+                            width: context.screenWidth,
+                            fit: BoxFit.cover,
+                            filterQuality: FilterQuality.high,
+                            placeholder: (context, url) => const Center(
+                              child: AppCircularIndicatorWidget(),
+                            ),
+                          ),
+                        ),
+                      ),
+                      Padding(
+                        padding: const EdgeInsets.all(AppThemeConstants.mediumPadding),
+                        child: Column(
+                          crossAxisAlignment: CrossAxisAlignment.start,
+                          children: [
+                            Text(
+                              item.createdAt.diaMesAnoHora(),
+                              style: context.textTheme.bodySmall,
+                            ),
+                            const SizedBox(height: 4),
+                            Text(item.description),
+                          ],
+                        ),
+                      ),
+                    ],
+                  ),
+                );
+              },
+            );
+          }
+
+          return const SizedBox.shrink();
+        },
+      ),
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- add a new module `my_plantings` with datasource, repository, use case and bloc
- register new dependencies for the module
- create `MyPlantingsPage` to list user plantings
- expose the screen through new route `NamedRoutes.myPlantings`
- add button on `CardUserWidget` to open the new page

## Testing
- `flutter pub run build_runner build --delete-conflicting-outputs` *(fails: flutter not installed)*

------
https://chatgpt.com/codex/tasks/task_e_686ec10ef1d883229da92301f358e668