### PR TITLE
Add logout confirmation dialog

### DIFF
--- a/lib/modules/home/presentation/widgets/card_user_widget.dart
+++ b/lib/modules/home/presentation/widgets/card_user_widget.dart
@@ -39,10 +39,44 @@ class _CardUserWidgetState extends State<CardUserWidget> {
 
     return IconButton(
       icon: const Icon(Icons.logout, color: Colors.white),
-      onPressed: () {
-        _authBloc.add(LogoutAccountEvent());
-      },
+      onPressed: _confirmLogout,
     );
+  }
+
+  Future<void> _confirmLogout() async {
+    final bool? shouldLogout = await showDialog<bool>(
+      context: context,
+      builder: (context) => AlertDialog(
+        backgroundColor: context.myTheme.primaryContainer,
+        shape: RoundedRectangleBorder(
+          borderRadius: BorderRadius.circular(
+            AppThemeConstants.largeBorderRadius,
+          ),
+        ),
+        title: Text(
+          'Sair',
+          style: context.textTheme.titleMedium,
+        ),
+        content: Text(
+          'Deseja realmente sair do aplicativo?',
+          style: context.textTheme.bodyLarge,
+        ),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.pop(context, false),
+            child: const Text('Cancelar'),
+          ),
+          TextButton(
+            onPressed: () => Navigator.pop(context, true),
+            child: const Text('Sair'),
+          ),
+        ],
+      ),
+    );
+
+    if (shouldLogout ?? false) {
+      _authBloc.add(LogoutAccountEvent());
+    }
   }
 
   void _listenAuthStates() {


### PR DESCRIPTION
## Summary
- confirm logout before dispatching event

## Testing
- `flutter analyze` *(fails: command not found)*
- `dart analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686ec94bc8fc8322ba58bf0ee0cf566a