### PR TITLE
Improve logout confirmation dialog

### DIFF
--- a/lib/modules/home/presentation/widgets/card_user_widget.dart
+++ b/lib/modules/home/presentation/widgets/card_user_widget.dart
@@ -47,15 +47,21 @@ class _CardUserWidgetState extends State<CardUserWidget> {
     final bool? shouldLogout = await showDialog<bool>(
       context: context,
       builder: (context) => AlertDialog(
-        backgroundColor: context.myTheme.primaryContainer,
+        backgroundColor: Colors.white,
         shape: RoundedRectangleBorder(
           borderRadius: BorderRadius.circular(
             AppThemeConstants.largeBorderRadius,
           ),
         ),
-        title: Text(
-          'Sair',
-          style: context.textTheme.titleMedium,
+        title: Row(
+          children: [
+            const Icon(Icons.logout),
+            const SizedBox(width: 8),
+            Text(
+              'Sair',
+              style: context.textTheme.titleMedium,
+            ),
+          ],
         ),
         content: Text(
           'Deseja realmente sair do aplicativo?',
@@ -66,7 +72,7 @@ class _CardUserWidgetState extends State<CardUserWidget> {
             onPressed: () => Navigator.pop(context, false),
             child: const Text('Cancelar'),
           ),
-          TextButton(
+          ElevatedButton(
             onPressed: () => Navigator.pop(context, true),
             child: const Text('Sair'),
           ),


### PR DESCRIPTION
## Summary
- tweak logout dialog style

## Testing
- `flutter --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686eefe4dd988322934c62348b08f87a