### PR TITLE
Add starter test suite

### DIFF
--- a/integration_test/app_e2e_test.dart
+++ b/integration_test/app_e2e_test.dart
@@ -1,0 +1,14 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:integration_test/integration_test.dart';
+import 'package:school_planting/main.dart' as app;
+
+void main() {
+  IntegrationTestWidgetsFlutterBinding.ensureInitialized();
+
+  testWidgets('full app startup', (tester) async {
+    app.main();
+    await tester.pumpAndSettle();
+
+    expect(find.text('Green Map'), findsOneWidget);
+  });
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -60,6 +60,8 @@ dependencies:
 dev_dependencies:
   flutter_test:
     sdk: flutter
+  integration_test:
+    sdk: flutter
 
   # The "flutter_lints" package below contains a set of recommended lints to
   # encourage good coding practices. The lint set provided by the package is

--- a/test/golden/app_widget_golden_test.dart
+++ b/test/golden/app_widget_golden_test.dart
@@ -1,0 +1,12 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:school_planting/app_widget.dart';
+
+void main() {
+  testWidgets('AppWidget matches golden file', (tester) async {
+    await tester.pumpWidget(const AppWidget());
+    await expectLater(
+      find.byType(AppWidget),
+      matchesGoldenFile('goldens/app_widget.png'),
+    );
+  });
+}

--- a/test/unit/constants_test.dart
+++ b/test/unit/constants_test.dart
@@ -1,0 +1,8 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:school_planting/core/constants/constants.dart';
+
+void main() {
+  test('kPadding constant is 20', () {
+    expect(kPadding, 20);
+  });
+}

--- a/test/widget/home_page_test.dart
+++ b/test/widget/home_page_test.dart
@@ -1,0 +1,15 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:school_planting/modules/home/presentation/home_page.dart';
+import 'package:school_planting/modules/home/presentation/widgets/card_user_widget.dart';
+import 'package:school_planting/modules/home/presentation/widgets/map_planting_widget.dart';
+
+void main() {
+  testWidgets('HomePage shows map and user card', (tester) async {
+    await tester.pumpWidget(const MaterialApp(home: HomePage()));
+
+    expect(find.byType(Stack), findsOneWidget);
+    expect(find.byType(MapPlantingWidget), findsOneWidget);
+    expect(find.byType(CardUserWidget), findsOneWidget);
+  });
+}


### PR DESCRIPTION
## Summary
- add basic unit, widget, golden and integration tests
- include integration_test as a dev dependency

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686ef0d0b3b88322abc9591af34480e9