### PR TITLE
Add Mockito unit tests

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -70,6 +70,7 @@ dev_dependencies:
   # rules and activating additional ones.
   flutter_lints: ^5.0.0
   build_runner: ^2.5.4
+  mockito: ^5.4.2
   injectable_generator: ^2.7.0
   flutter_launcher_icons: ^0.13.1
 

--- a/test/helpers/mocks.dart
+++ b/test/helpers/mocks.dart
@@ -1,0 +1,22 @@
+import 'package:mockito/mockito.dart';
+import 'package:school_planting/core/data/clients/supabase/supabase_client_interface.dart';
+import 'package:school_planting/modules/auth/data/datasources/auth_datasource.dart';
+import 'package:school_planting/modules/auth/domain/repositories/auth_repository.dart';
+import 'package:school_planting/modules/home/data/datasources/map_planting_datasource.dart';
+import 'package:school_planting/modules/home/domain/repositories/map_planting_repository.dart';
+import 'package:school_planting/modules/my_plantings/data/datasources/my_plantings_datasource.dart';
+import 'package:school_planting/modules/my_plantings/domain/repositories/my_plantings_repository.dart';
+import 'package:school_planting/modules/planting/data/datasources/planting_datasource.dart';
+import 'package:school_planting/modules/planting/domain/repositories/planting_repository.dart';
+import 'package:supabase_flutter/supabase_flutter.dart';
+
+class MockAuthRepository extends Mock implements AuthRepository {}
+class MockAuthDatasource extends Mock implements AuthDatasource {}
+class MockISupabaseClient extends Mock implements ISupabaseClient {}
+class MockMapPlantingRepository extends Mock implements MapPlantingRepository {}
+class MockMapPlantingDatasource extends Mock implements MapPlantingDatasource {}
+class MockMyPlantingsRepository extends Mock implements MyPlantingsRepository {}
+class MockMyPlantingsDatasource extends Mock implements MyPlantingsDatasource {}
+class MockPlantingRepository extends Mock implements PlantingRepository {}
+class MockPlantingDatasource extends Mock implements PlantingDatasource {}
+class MockSupabaseUser extends Mock implements User {}

--- a/test/unit/auth/auth_datasource_impl_test.dart
+++ b/test/unit/auth/auth_datasource_impl_test.dart
@@ -1,0 +1,49 @@
+import 'dart:async';
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:school_planting/modules/auth/data/datasources/auth_datasource_impl.dart';
+import 'package:school_planting/modules/auth/domain/entities/user_entity.dart';
+import 'package:supabase_flutter/supabase_flutter.dart';
+
+import '../../helpers/mocks.dart';
+import 'package:mockito/mockito.dart';
+
+void main() {
+  group('AuthDatasourceImpl', () {
+    late MockISupabaseClient client;
+    late AuthDatasourceImpl datasource;
+
+    setUp(() {
+      client = MockISupabaseClient();
+      datasource = AuthDatasourceImpl(supabaseClient: client);
+    });
+
+    test('autoLogin returns null when no user', () async {
+      when(client.currentUser).thenReturn(null);
+
+      final result = await datasource.autoLogin();
+
+      expect(result, isNull);
+    });
+
+    test('autoLogin returns entity when user exists', () async {
+      final user = MockSupabaseUser();
+      when(user.id).thenReturn('1');
+      when(user.email).thenReturn('mail@test.com');
+      when(user.userMetadata).thenReturn({'name': 'User', 'avatar_url': 'img'});
+      when(client.currentUser).thenReturn(user);
+
+      final result = await datasource.autoLogin();
+
+      expect(result, isA<UserEntity>());
+      expect(result!.id.value, '1');
+    });
+
+    test('logout calls signOut', () async {
+      when(client.signOut()).thenAnswer((_) async => {});
+      await datasource.logout();
+      verify(client.signOut()).called(1);
+    });
+  });
+}

--- a/test/unit/auth/auth_repository_impl_test.dart
+++ b/test/unit/auth/auth_repository_impl_test.dart
@@ -1,0 +1,61 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:school_planting/core/domain/entities/either_of.dart';
+import 'package:school_planting/modules/auth/data/repositories/auth_repository_impl.dart';
+import 'package:school_planting/modules/auth/domain/entities/auth_exception.dart';
+import 'package:school_planting/modules/auth/domain/entities/user_entity.dart';
+import 'package:school_planting/modules/auth/domain/repositories/auth_repository.dart';
+
+import '../../helpers/mocks.dart';
+import 'package:mockito/mockito.dart';
+
+void main() {
+  group('AuthRepositoryImpl', () {
+    late MockAuthDatasource datasource;
+    late AuthRepository repository;
+
+    setUp(() {
+      datasource = MockAuthDatasource();
+      repository = AuthRepositoryImpl(authDatasource: datasource);
+    });
+
+    test('loginWithGoogleAccount returns user on success', () async {
+      final user = UserEntity(id: '1', email: 'a', name: 'b');
+      when(datasource.loginWithGoogleAccount()).thenAnswer((_) async => user);
+
+      final result = await repository.loginWithGoogleAccount();
+
+      verify(datasource.loginWithGoogleAccount()).called(1);
+      expect(result.isRight, true);
+    });
+
+    test('loginWithGoogleAccount returns failure on exception', () async {
+      when(datasource.loginWithGoogleAccount()).thenThrow(Exception('err'));
+
+      final result = await repository.loginWithGoogleAccount();
+
+      expect(result.isLeft, true);
+      result.get((failure) {
+        expect(failure, isA<AuthException>());
+        return null;
+      }, (_) => null);
+    });
+
+    test('autoLogin returns data from datasource', () async {
+      when(datasource.autoLogin()).thenAnswer((_) async => null);
+
+      final result = await repository.autoLogin();
+
+      verify(datasource.autoLogin()).called(1);
+      expect(result.isRight, true);
+    });
+
+    test('logout returns success', () async {
+      when(datasource.logout()).thenAnswer((_) async => {});
+
+      final result = await repository.logout();
+
+      verify(datasource.logout()).called(1);
+      expect(result.isRight, true);
+    });
+  });
+}

--- a/test/unit/auth/auth_usecases_test.dart
+++ b/test/unit/auth/auth_usecases_test.dart
@@ -1,0 +1,52 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:school_planting/core/domain/entities/either_of.dart';
+import 'package:school_planting/core/domain/entities/usecase.dart';
+import 'package:school_planting/modules/auth/domain/entities/user_entity.dart';
+import 'package:school_planting/modules/auth/domain/usecases/auto_login.dart';
+import 'package:school_planting/modules/auth/domain/usecases/login_with_google_account.dart';
+import 'package:school_planting/modules/auth/domain/usecases/logout_account.dart';
+
+import '../../helpers/mocks.dart';
+import 'package:mockito/mockito.dart';
+
+void main() {
+  group('Auth usecases', () {
+    late MockAuthRepository repository;
+    late LoginWithGoogleAccountUseCase login;
+    late AutoLoginUseCase autoLogin;
+    late LogoutAccountUsecase logout;
+
+    setUp(() {
+      repository = MockAuthRepository();
+      login = LoginWithGoogleAccountUseCase(authRepository: repository);
+      autoLogin = AutoLoginUseCase(authRepository: repository);
+      logout = LogoutAccountUsecase(authRepository: repository);
+    });
+
+    test('login calls repository', () async {
+      final user = UserEntity(id: '1', email: 'a', name: 'b');
+      when(repository.loginWithGoogleAccount())
+          .thenAnswer((_) async => resolve(user));
+
+      final result = await login(const NoArgs());
+
+      verify(repository.loginWithGoogleAccount()).called(1);
+      expect(result.isRight, true);
+    });
+
+    test('autoLogin calls repository', () async {
+      when(repository.autoLogin()).thenAnswer((_) async => resolve(null));
+      final result = await autoLogin(const NoArgs());
+      verify(repository.autoLogin()).called(1);
+      expect(result.isRight, true);
+    });
+
+    test('logout calls repository', () async {
+      when(repository.logout())
+          .thenAnswer((_) async => resolve(const VoidSuccess()));
+      final result = await logout(const NoArgs());
+      verify(repository.logout()).called(1);
+      expect(result.isRight, true);
+    });
+  });
+}

--- a/test/unit/home/map_planting_datasource_impl_test.dart
+++ b/test/unit/home/map_planting_datasource_impl_test.dart
@@ -1,0 +1,48 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:school_planting/modules/home/data/datasources/map_planting_datasource_impl.dart';
+import 'package:school_planting/modules/home/domain/entities/planting_detail_entity.dart';
+import 'package:mockito/mockito.dart';
+
+import '../../helpers/mocks.dart';
+
+void main() {
+  group('MapPlantingDatasourceImpl', () {
+    late MockISupabaseClient client;
+    late MapPlantingDatasourceImpl datasource;
+
+    setUp(() {
+      client = MockISupabaseClient();
+      datasource = MapPlantingDatasourceImpl(supabaseClient: client);
+    });
+
+    test('fetchPlantings parses data correctly', () async {
+      when(client.select(
+        table: anyNamed('table'),
+        columns: anyNamed('columns'),
+      )).thenAnswer((_) async => [
+            {
+              'description': 'd',
+              'image_url': 'img.jpg',
+              'user_name': 'u',
+              'photourl': 'p',
+              'lat': 1,
+              'long': 2,
+              'created_at': '2024-01-01T00:00:00Z'
+            }
+          ]);
+
+      when(client.getImageUrl(
+        bucket: anyNamed('bucket'),
+        path: anyNamed('path'),
+      )).thenAnswer((_) async => 'url');
+
+      final result = await datasource.fetchPlantings();
+
+      expect(result, isA<List<PlantingDetailEntity>>());
+      expect(result.first.imageUrl, 'url');
+      verify(client.select(table: 'user_plantings_with_userinfo',
+              columns: 'description,image_url,lat,long,user_name,photourl,created_at'))
+          .called(1);
+    });
+  });
+}

--- a/test/unit/home/map_planting_repository_impl_test.dart
+++ b/test/unit/home/map_planting_repository_impl_test.dart
@@ -1,0 +1,44 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:school_planting/modules/home/data/repositories/map_planting_repository_impl.dart';
+import 'package:school_planting/modules/home/domain/entities/planting_detail_entity.dart';
+import 'package:school_planting/modules/home/domain/exceptions/home_exception.dart';
+import 'package:school_planting/modules/home/domain/repositories/map_planting_repository.dart';
+import 'package:school_planting/core/domain/entities/either_of.dart';
+import 'package:school_planting/core/domain/entities/failure.dart';
+
+import '../../helpers/mocks.dart';
+import 'package:mockito/mockito.dart';
+
+void main() {
+  group('MapPlantingRepositoryImpl', () {
+    late MockMapPlantingDatasource datasource;
+    late MapPlantingRepository repository;
+
+    setUp(() {
+      datasource = MockMapPlantingDatasource();
+      repository = MapPlantingRepositoryImpl(datasource: datasource);
+    });
+
+    test('returns plantings on success', () async {
+      when(datasource.fetchPlantings())
+          .thenAnswer((_) async => <PlantingDetailEntity>[]);
+
+      final result = await repository.getPlantings();
+
+      verify(datasource.fetchPlantings()).called(1);
+      expect(result.isRight, true);
+    });
+
+    test('returns failure on error', () async {
+      when(datasource.fetchPlantings()).thenThrow(Exception('err'));
+
+      final result = await repository.getPlantings();
+
+      expect(result.isLeft, true);
+      result.get((failure) {
+        expect(failure, isA<HomeException>());
+        return null;
+      }, (_) => null);
+    });
+  });
+}

--- a/test/unit/home/map_planting_usecase_test.dart
+++ b/test/unit/home/map_planting_usecase_test.dart
@@ -1,0 +1,30 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:school_planting/core/domain/entities/either_of.dart';
+import 'package:school_planting/core/domain/entities/usecase.dart';
+import 'package:school_planting/modules/home/domain/entities/planting_detail_entity.dart';
+import 'package:school_planting/modules/home/domain/usecases/get_plantings_usecase.dart';
+
+import '../../helpers/mocks.dart';
+import 'package:mockito/mockito.dart';
+
+void main() {
+  group('GetPlantingsUseCase', () {
+    late MockMapPlantingRepository repository;
+    late GetPlantingsUseCase usecase;
+
+    setUp(() {
+      repository = MockMapPlantingRepository();
+      usecase = GetPlantingsUseCase(repository: repository);
+    });
+
+    test('calls repository to get plantings', () async {
+      when(repository.getPlantings())
+          .thenAnswer((_) async => resolve(<PlantingDetailEntity>[]));
+
+      final result = await usecase(const NoArgs());
+
+      verify(repository.getPlantings()).called(1);
+      expect(result.isRight, true);
+    });
+  });
+}

--- a/test/unit/my_plantings/get_my_plantings_usecase_test.dart
+++ b/test/unit/my_plantings/get_my_plantings_usecase_test.dart
@@ -1,0 +1,30 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:school_planting/core/domain/entities/either_of.dart';
+import 'package:school_planting/core/domain/entities/usecase.dart';
+import 'package:school_planting/modules/my_plantings/domain/entities/my_planting_entity.dart';
+import 'package:school_planting/modules/my_plantings/domain/usecases/get_my_plantings_usecase.dart';
+
+import '../../helpers/mocks.dart';
+import 'package:mockito/mockito.dart';
+
+void main() {
+  group('GetMyPlantingsUseCase', () {
+    late MockMyPlantingsRepository repository;
+    late GetMyPlantingsUseCase usecase;
+
+    setUp(() {
+      repository = MockMyPlantingsRepository();
+      usecase = GetMyPlantingsUseCase(repository: repository);
+    });
+
+    test('calls repository to fetch plantings', () async {
+      when(repository.getMyPlantings())
+          .thenAnswer((_) async => resolve(<MyPlantingEntity>[]));
+
+      final result = await usecase(const NoArgs());
+
+      verify(repository.getMyPlantings()).called(1);
+      expect(result.isRight, true);
+    });
+  });
+}

--- a/test/unit/my_plantings/my_plantings_datasource_impl_test.dart
+++ b/test/unit/my_plantings/my_plantings_datasource_impl_test.dart
@@ -1,0 +1,49 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:school_planting/modules/my_plantings/data/datasources/my_plantings_datasource_impl.dart';
+import 'package:school_planting/modules/my_plantings/domain/entities/my_planting_entity.dart';
+import 'package:mockito/mockito.dart';
+
+import '../../helpers/mocks.dart';
+
+void main() {
+  group('MyPlantingsDatasourceImpl', () {
+    late MockISupabaseClient client;
+    late MyPlantingsDatasourceImpl datasource;
+
+    setUp(() {
+      client = MockISupabaseClient();
+      datasource = MyPlantingsDatasourceImpl(supabaseClient: client);
+    });
+
+    test('fetchMyPlantings parses data', () async {
+      when(client.select(
+        table: anyNamed('table'),
+        columns: anyNamed('columns'),
+        filters: anyNamed('filters'),
+        orderBy: anyNamed('orderBy'),
+      )).thenAnswer((_) async => [
+            {
+              'description': 'd',
+              'image_url': 'img.jpg',
+              'lat': 1,
+              'long': 2,
+              'created_at': '2024-01-01T00:00:00Z'
+            }
+          ]);
+      when(client.getImageUrl(
+        bucket: anyNamed('bucket'),
+        path: anyNamed('path'),
+      )).thenAnswer((_) async => 'url');
+
+      final result = await datasource.fetchMyPlantings('1');
+
+      expect(result, isA<List<MyPlantingEntity>>());
+      expect(result.first.imageUrl, 'url');
+      verify(client.select(table: 'user_plantings_with_userinfo',
+              columns: 'description,image_url,lat,long,user_name,photourl,created_at',
+              filters: {'user_id': '1'},
+              orderBy: 'created_at'))
+          .called(1);
+    });
+  });
+}

--- a/test/unit/my_plantings/my_plantings_repository_impl_test.dart
+++ b/test/unit/my_plantings/my_plantings_repository_impl_test.dart
@@ -1,0 +1,33 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:school_planting/core/domain/entities/either_of.dart';
+import 'package:school_planting/core/domain/entities/app_global.dart';
+import 'package:school_planting/modules/auth/domain/entities/user_entity.dart';
+import 'package:school_planting/modules/my_plantings/data/repositories/my_plantings_repository_impl.dart';
+import 'package:school_planting/modules/my_plantings/domain/entities/my_planting_entity.dart';
+import 'package:school_planting/modules/my_plantings/domain/repositories/my_plantings_repository.dart';
+
+import '../../helpers/mocks.dart';
+import 'package:mockito/mockito.dart';
+
+void main() {
+  group('MyPlantingsRepositoryImpl', () {
+    late MockMyPlantingsDatasource datasource;
+    late MyPlantingsRepository repository;
+
+    setUp(() {
+      datasource = MockMyPlantingsDatasource();
+      repository = MyPlantingsRepositoryImpl(datasource: datasource);
+      AppGlobal(user: UserEntity(id: '1', email: 'e', name: 'n'));
+    });
+
+    test('returns plantings on success', () async {
+      when(datasource.fetchMyPlantings(any))
+          .thenAnswer((_) async => <MyPlantingEntity>[]);
+
+      final result = await repository.getMyPlantings();
+
+      verify(datasource.fetchMyPlantings('1')).called(1);
+      expect(result.isRight, true);
+    });
+  });
+}

--- a/test/unit/planting/create_planting_usecase_test.dart
+++ b/test/unit/planting/create_planting_usecase_test.dart
@@ -1,0 +1,41 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:school_planting/core/domain/entities/either_of.dart';
+import 'package:school_planting/core/domain/entities/usecase.dart';
+import 'package:school_planting/modules/planting/domain/entities/planting_entity.dart';
+import 'package:school_planting/modules/planting/domain/usecases/create_planting_usecase.dart';
+
+import '../../helpers/mocks.dart';
+import 'package:mockito/mockito.dart';
+
+void main() {
+  group('CreatePlantingUseCase', () {
+    late MockPlantingRepository repository;
+    late CreatePlantingUseCase usecase;
+
+    setUp(() {
+      repository = MockPlantingRepository();
+      usecase = CreatePlantingUseCase(repository: repository);
+    });
+
+    test('calls repository to create planting', () async {
+      when(repository.createPlanting(any, any))
+          .thenAnswer((_) async => resolve(const VoidSuccess()));
+
+      final entity = PlantingEntity(
+          description: 'd',
+          imageName: 'img',
+          userId: '1',
+          latitude: 1,
+          longitude: 2);
+      final file = File('test.txt');
+      final params = CreatePlantingParams(entity: entity, image: file);
+
+      final result = await usecase(params);
+
+      verify(repository.createPlanting(entity, file)).called(1);
+      expect(result.isRight, true);
+    });
+  });
+}

--- a/test/unit/planting/planting_datasource_impl_test.dart
+++ b/test/unit/planting/planting_datasource_impl_test.dart
@@ -1,0 +1,46 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:school_planting/modules/planting/data/datasources/planting_datasource_impl.dart';
+import 'package:mockito/mockito.dart';
+
+import '../../helpers/mocks.dart';
+
+void main() {
+  group('PlantingDatasourceImpl', () {
+    late MockISupabaseClient client;
+    late PlantingDatasourceImpl datasource;
+
+    setUp(() {
+      client = MockISupabaseClient();
+      datasource = PlantingDatasourceImpl(supabaseClient: client);
+    });
+
+    test('upload and insert are called', () async {
+      when(client.uploadFile(
+        bucket: anyNamed('bucket'),
+        path: anyNamed('path'),
+        file: anyNamed('file'),
+      )).thenAnswer((_) async => {});
+      when(client.insert(
+        table: anyNamed('table'),
+        data: anyNamed('data'),
+      )).thenAnswer((_) async => {});
+
+      final file = File('tmp.txt');
+      await file.writeAsString('x');
+
+      await datasource.createPlanting(
+        userId: '1',
+        description: 'd',
+        image: file,
+        imageName: 'img',
+        lat: 1,
+        long: 2,
+      );
+
+      verify(client.uploadFile(bucket: 'escolaverdebucket', path: 'private/img', file: anyNamed('file'))).called(1);
+      verify(client.insert(table: 'user_plantings', data: anyNamed('data'))).called(1);
+    });
+  });
+}

--- a/test/unit/planting/planting_repository_impl_test.dart
+++ b/test/unit/planting/planting_repository_impl_test.dart
@@ -1,0 +1,75 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:school_planting/modules/planting/data/repositories/planting_repository_impl.dart';
+import 'package:school_planting/modules/planting/domain/entities/planting_entity.dart';
+import 'package:school_planting/modules/planting/domain/exceptions/planting_exception.dart';
+import 'package:school_planting/modules/planting/domain/repositories/planting_repository.dart';
+import 'package:school_planting/core/domain/entities/either_of.dart';
+import 'package:mockito/mockito.dart';
+
+import '../../helpers/mocks.dart';
+
+void main() {
+  group('PlantingRepositoryImpl', () {
+    late MockPlantingDatasource datasource;
+    late PlantingRepository repository;
+
+    setUp(() {
+      datasource = MockPlantingDatasource();
+      repository = PlantingRepositoryImpl(datasource: datasource);
+    });
+
+    test('returns success on createPlanting', () async {
+      when(datasource.createPlanting(
+        userId: anyNamed('userId'),
+        description: anyNamed('description'),
+        image: anyNamed('image'),
+        imageName: anyNamed('imageName'),
+        lat: anyNamed('lat'),
+        long: anyNamed('long'),
+      )).thenAnswer((_) async => {});
+
+      final entity = PlantingEntity(
+          description: 'd',
+          imageName: 'img',
+          userId: '1',
+          latitude: 1,
+          longitude: 2);
+
+      final file = File('f');
+      final result =
+          await repository.createPlanting(entity, file);
+
+      expect(result.isRight, true);
+    });
+
+    test('returns failure on error', () async {
+      when(datasource.createPlanting(
+        userId: anyNamed('userId'),
+        description: anyNamed('description'),
+        image: anyNamed('image'),
+        imageName: anyNamed('imageName'),
+        lat: anyNamed('lat'),
+        long: anyNamed('long'),
+      )).thenThrow(Exception('e'));
+
+      final entity = PlantingEntity(
+          description: 'd',
+          imageName: 'img',
+          userId: '1',
+          latitude: 1,
+          longitude: 2);
+
+      final file = File('f');
+      final result =
+          await repository.createPlanting(entity, file);
+
+      expect(result.isLeft, true);
+      result.get((failure) {
+        expect(failure, isA<PlantingException>());
+        return null;
+      }, (_) => null);
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- add Mockito to dev dependencies
- add mock classes for interfaces
- implement unit tests for usecases, repositories, and datasources across modules

## Testing
- `dart test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686ef28aa834832294496f84ba9819d5