### PR TITLE
Refactor tests to use real parameters

### DIFF
--- a/test/unit/my_plantings/my_plantings_datasource_impl_test.dart
+++ b/test/unit/my_plantings/my_plantings_datasource_impl_test.dart
@@ -21,7 +21,7 @@ void main() {
           table: 'user_plantings_with_userinfo',
           columns:
               'description,image_url,lat,long,user_name,photourl,created_at',
-          filters: {'user_id': 'asdsadsadsadsa'},
+          filters: {'user_id': '1'},
           orderBy: 'created_at',
         ),
       ).thenAnswer(

--- a/test/unit/planting/create_planting_usecase_test.dart
+++ b/test/unit/planting/create_planting_usecase_test.dart
@@ -19,18 +19,19 @@ void main() {
     });
 
     test('calls repository to create planting', () async {
-      when(
-        repository.createPlanting(any, any),
-      ).thenAnswer((_) async => resolve(const VoidSuccess()));
-
       final entity = PlantingEntity(
-        description: 'd',
-        imageName: 'img',
-        userId: '1',
-        latitude: 1,
-        longitude: 2,
+        description: '',
+        imageName: '',
+        userId: '',
+        latitude: 0,
+        longitude: 0,
       );
       final file = File('test.txt');
+
+      when(
+        repository.createPlanting(entity, file),
+      ).thenAnswer((_) async => resolve(const VoidSuccess()));
+
       final params = CreatePlantingParams(entity: entity, image: file);
 
       final result = await usecase(params);

--- a/test/unit/planting/planting_datasource_impl_test.dart
+++ b/test/unit/planting/planting_datasource_impl_test.dart
@@ -17,19 +17,28 @@ void main() {
     });
 
     test('upload and insert are called', () async {
+      final file = File('tmp.txt');
+      await file.writeAsString('x');
+
       when(
         client.uploadFile(
-          bucket: anyNamed('bucket'),
-          path: anyNamed('path'),
-          file: anyNamed('file'),
+          bucket: 'escolaverdebucket',
+          path: 'private/img',
+          file: file,
         ),
       ).thenAnswer((_) async => {});
       when(
-        client.insert(table: 'user_plantings', data: anyNamed('data')),
+        client.insert(
+          table: 'user_plantings',
+          data: {
+            'user_id': '1',
+            'description': 'd',
+            'image_url': 'img',
+            'lat': 1,
+            'long': 2,
+          },
+        ),
       ).thenAnswer((_) async => {});
-
-      final file = File('tmp.txt');
-      await file.writeAsString('x');
 
       await datasource.createPlanting(
         userId: '1',
@@ -44,11 +53,20 @@ void main() {
         client.uploadFile(
           bucket: 'escolaverdebucket',
           path: 'private/img',
-          file: anyNamed('file'),
+          file: file,
         ),
       ).called(1);
       verify(
-        client.insert(table: 'user_plantings', data: anyNamed('data')),
+        client.insert(
+          table: 'user_plantings',
+          data: {
+            'user_id': '1',
+            'description': 'd',
+            'image_url': 'img',
+            'lat': 1,
+            'long': 2,
+          },
+        ),
       ).called(1);
     });
   });

--- a/test/unit/planting/planting_repository_impl_test.dart
+++ b/test/unit/planting/planting_repository_impl_test.dart
@@ -20,52 +20,53 @@ void main() {
     });
 
     test('returns success on createPlanting', () async {
-      when(
-        datasource.createPlanting(
-          userId: anyNamed('userId'),
-          description: anyNamed('description'),
-          image: anyNamed('image'),
-          imageName: anyNamed('imageName'),
-          lat: anyNamed('lat'),
-          long: anyNamed('long'),
-        ),
-      ).thenAnswer((_) async => {});
-
       final entity = PlantingEntity(
-        description: 'd',
-        imageName: 'img',
-        userId: '1',
-        latitude: 1,
-        longitude: 2,
+        description: '',
+        imageName: '',
+        userId: '',
+        latitude: 0,
+        longitude: 0,
       );
 
       final file = File('f');
+
+      when(
+        datasource.createPlanting(
+          userId: '',
+          description: '',
+          image: file,
+          imageName: '',
+          lat: 0,
+          long: 0,
+        ),
+      ).thenAnswer((_) async => {});
+
       final result = await repository.createPlanting(entity, file);
 
       expect(result.isRight, true);
     });
 
     test('returns failure on error', () async {
-      when(
-        datasource.createPlanting(
-          userId: anyNamed('userId'),
-          description: anyNamed('description'),
-          image: anyNamed('image'),
-          imageName: anyNamed('imageName'),
-          lat: anyNamed('lat'),
-          long: anyNamed('long'),
-        ),
-      ).thenThrow(Exception('e'));
-
       final entity = PlantingEntity(
-        description: 'd',
-        imageName: 'img',
-        userId: '1',
-        latitude: 1,
-        longitude: 2,
+        description: '',
+        imageName: '',
+        userId: '',
+        latitude: 0,
+        longitude: 0,
       );
 
       final file = File('f');
+
+      when(
+        datasource.createPlanting(
+          userId: '',
+          description: '',
+          image: file,
+          imageName: '',
+          lat: 0,
+          long: 0,
+        ),
+      ).thenThrow(Exception('e'));
       final result = await repository.createPlanting(entity, file);
 
       expect(result.isLeft, true);


### PR DESCRIPTION
## Summary
- remove all `anyNamed` usage from plantings tests
- stub mocked calls with real table names, columns and filters
- create blank `PlantingEntity` and `File` instances where needed

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686ef6276e9c8322bdea311959e10b66