### PR TITLE
Add environmental impact module

### DIFF
--- a/lib/core/domain/entities/named_routes.dart
+++ b/lib/core/domain/entities/named_routes.dart
@@ -3,7 +3,8 @@ enum NamedRoutes {
   auth('/auth'),
   home('/home'),
   planting('/planting'),
-  myPlantings('/my-plantings');
+  myPlantings('/my-plantings'),
+  impact('/impact');
 
   final String route;
   const NamedRoutes(this.route);

--- a/lib/core/routes/app_routes.dart
+++ b/lib/core/routes/app_routes.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:school_planting/modules/auth/presentation/auth_page.dart';
 import 'package:school_planting/modules/home/presentation/home_page.dart';
 import 'package:school_planting/modules/my_plantings/presentation/my_plantings_page.dart';
+import 'package:school_planting/modules/impact/presentation/impact_page.dart';
 import 'package:school_planting/modules/splash/presentation/splash_page.dart';
 import 'package:school_planting/modules/planting/presentation/planting_page.dart';
 
@@ -21,6 +22,7 @@ class CustomNavigator {
       NamedRoutes.home.route: (BuildContext context) => const HomePage(),
       NamedRoutes.planting.route: (BuildContext context) => const PlantingPage(),
       NamedRoutes.myPlantings.route: (BuildContext context) => const MyPlantingsPage(),
+      NamedRoutes.impact.route: (BuildContext context) => const ImpactPage(),
     };
 
     final WidgetBuilder? builder = appRoutes[settings.name];

--- a/lib/modules/home/presentation/widgets/card_user_widget.dart
+++ b/lib/modules/home/presentation/widgets/card_user_widget.dart
@@ -174,6 +174,12 @@ class _CardUserWidgetState extends State<CardUserWidget> {
                   Navigator.pushNamed(context, NamedRoutes.myPlantings.route);
                 },
               ),
+              IconButton(
+                icon: const Icon(Icons.eco, color: Colors.white),
+                onPressed: () {
+                  Navigator.pushNamed(context, NamedRoutes.impact.route);
+                },
+              ),
               BlocBuilder<AuthBloc, AuthStates>(
                 bloc: _authBloc,
                 builder: (context, states) {

--- a/lib/modules/impact/data/datasources/impact_datasource.dart
+++ b/lib/modules/impact/data/datasources/impact_datasource.dart
@@ -1,0 +1,3 @@
+abstract class ImpactDatasource {
+  Future<int> countPlantings(String userId);
+}

--- a/lib/modules/impact/data/datasources/impact_datasource_impl.dart
+++ b/lib/modules/impact/data/datasources/impact_datasource_impl.dart
@@ -1,0 +1,22 @@
+import 'package:injectable/injectable.dart';
+import 'package:school_planting/core/data/clients/supabase/supabase_client_interface.dart';
+
+import 'impact_datasource.dart';
+
+@Injectable(as: ImpactDatasource)
+class ImpactDatasourceImpl implements ImpactDatasource {
+  final ISupabaseClient _client;
+
+  ImpactDatasourceImpl({required ISupabaseClient supabaseClient})
+      : _client = supabaseClient;
+
+  @override
+  Future<int> countPlantings(String userId) async {
+    final data = await _client.select(
+      table: 'user_plantings',
+      columns: 'id',
+      filters: {'user_id': userId},
+    );
+    return data.length;
+  }
+}

--- a/lib/modules/impact/data/repositories/impact_repository_impl.dart
+++ b/lib/modules/impact/data/repositories/impact_repository_impl.dart
@@ -1,0 +1,30 @@
+import 'package:injectable/injectable.dart';
+import 'package:school_planting/core/domain/entities/either_of.dart';
+import 'package:school_planting/core/domain/entities/failure.dart';
+import 'package:school_planting/core/domain/entities/app_global.dart';
+import 'package:school_planting/modules/impact/data/datasources/impact_datasource.dart';
+import 'package:school_planting/modules/impact/domain/entities/impact_entity.dart';
+import 'package:school_planting/modules/impact/domain/exceptions/impact_exception.dart';
+import 'package:school_planting/modules/impact/domain/repositories/impact_repository.dart';
+
+@Injectable(as: ImpactRepository)
+class ImpactRepositoryImpl implements ImpactRepository {
+  final ImpactDatasource _datasource;
+
+  ImpactRepositoryImpl({required ImpactDatasource datasource})
+      : _datasource = datasource;
+
+  @override
+  Future<EitherOf<AppFailure, ImpactEntity>> getImpactData() async {
+    try {
+      final userId = AppGlobal.instance.user?.id.value ?? '';
+      final count = await _datasource.countPlantings(userId);
+      final impact = ImpactEntity.fromCount(count);
+      return resolve(impact);
+    } on AppFailure catch (e) {
+      return reject(e);
+    } catch (e) {
+      return reject(ImpactException(e.toString()));
+    }
+  }
+}

--- a/lib/modules/impact/domain/entities/impact_entity.dart
+++ b/lib/modules/impact/domain/entities/impact_entity.dart
@@ -1,0 +1,35 @@
+class ImpactEntity {
+  final double oxygen;
+  final double carbon;
+  final double temperature;
+  final double water;
+  final double biodiversity;
+  final double airQuality;
+
+  ImpactEntity({
+    required this.oxygen,
+    required this.carbon,
+    required this.temperature,
+    required this.water,
+    required this.biodiversity,
+    required this.airQuality,
+  });
+
+  factory ImpactEntity.fromCount(int count) {
+    const double oxygenPerPlant = 120.0;
+    const double carbonPerPlant = 22.0;
+    const double temperaturePerPlant = 0.1;
+    const double waterPerPlant = 50.0;
+    const double biodiversityPerPlant = 1.0;
+    const double airQualityPerPlant = 1.0;
+
+    return ImpactEntity(
+      oxygen: oxygenPerPlant * count,
+      carbon: carbonPerPlant * count,
+      temperature: temperaturePerPlant * count,
+      water: waterPerPlant * count,
+      biodiversity: biodiversityPerPlant * count,
+      airQuality: airQualityPerPlant * count,
+    );
+  }
+}

--- a/lib/modules/impact/domain/exceptions/impact_exception.dart
+++ b/lib/modules/impact/domain/exceptions/impact_exception.dart
@@ -1,0 +1,5 @@
+import 'package:school_planting/core/domain/entities/failure.dart';
+
+class ImpactException extends AppFailure {
+  ImpactException(super.message);
+}

--- a/lib/modules/impact/domain/repositories/impact_repository.dart
+++ b/lib/modules/impact/domain/repositories/impact_repository.dart
@@ -1,0 +1,7 @@
+import 'package:school_planting/core/domain/entities/either_of.dart';
+import 'package:school_planting/core/domain/entities/failure.dart';
+import '../entities/impact_entity.dart';
+
+abstract class ImpactRepository {
+  Future<EitherOf<AppFailure, ImpactEntity>> getImpactData();
+}

--- a/lib/modules/impact/domain/usecases/get_impact_usecase.dart
+++ b/lib/modules/impact/domain/usecases/get_impact_usecase.dart
@@ -1,0 +1,19 @@
+import 'package:injectable/injectable.dart';
+import 'package:school_planting/core/domain/entities/either_of.dart';
+import 'package:school_planting/core/domain/entities/failure.dart';
+import 'package:school_planting/core/domain/entities/usecase.dart';
+import '../entities/impact_entity.dart';
+import '../repositories/impact_repository.dart';
+
+@injectable
+class GetImpactUseCase implements UseCase<ImpactEntity, NoArgs> {
+  final ImpactRepository _repository;
+
+  GetImpactUseCase({required ImpactRepository repository})
+      : _repository = repository;
+
+  @override
+  Future<EitherOf<AppFailure, ImpactEntity>> call(NoArgs args) {
+    return _repository.getImpactData();
+  }
+}

--- a/lib/modules/impact/presentation/controller/impact_bloc.dart
+++ b/lib/modules/impact/presentation/controller/impact_bloc.dart
@@ -1,0 +1,29 @@
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:school_planting/core/domain/entities/usecase.dart';
+import '../../domain/usecases/get_impact_usecase.dart';
+import 'impact_events.dart';
+import 'impact_states.dart';
+
+class ImpactBloc extends Bloc<ImpactEvents, ImpactStates> {
+  final GetImpactUseCase _usecase;
+
+  ImpactBloc({required GetImpactUseCase usecase})
+      : _usecase = usecase,
+        super(ImpactInitialState()) {
+    on<LoadImpactEvent>(_onLoadImpact);
+  }
+
+  Future<void> _onLoadImpact(
+    LoadImpactEvent event,
+    Emitter<ImpactStates> emit,
+  ) async {
+    emit(state.loading());
+
+    final result = await _usecase(const NoArgs());
+
+    result.get(
+      (failure) => emit(state.failure(failure.message)),
+      (data) => emit(state.success(data)),
+    );
+  }
+}

--- a/lib/modules/impact/presentation/controller/impact_events.dart
+++ b/lib/modules/impact/presentation/controller/impact_events.dart
@@ -1,0 +1,3 @@
+abstract class ImpactEvents {}
+
+class LoadImpactEvent extends ImpactEvents {}

--- a/lib/modules/impact/presentation/controller/impact_states.dart
+++ b/lib/modules/impact/presentation/controller/impact_states.dart
@@ -1,0 +1,21 @@
+import '../../domain/entities/impact_entity.dart';
+
+abstract class ImpactStates {
+  ImpactLoadingState loading() => ImpactLoadingState();
+  ImpactFailureState failure(String message) => ImpactFailureState(message);
+  ImpactSuccessState success(ImpactEntity data) => ImpactSuccessState(data);
+}
+
+class ImpactInitialState extends ImpactStates {}
+
+class ImpactLoadingState extends ImpactStates {}
+
+class ImpactFailureState extends ImpactStates {
+  final String message;
+  ImpactFailureState(this.message);
+}
+
+class ImpactSuccessState extends ImpactStates {
+  final ImpactEntity metrics;
+  ImpactSuccessState(this.metrics);
+}

--- a/lib/modules/impact/presentation/impact_page.dart
+++ b/lib/modules/impact/presentation/impact_page.dart
@@ -1,0 +1,94 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:school_planting/core/di/dependency_injection.dart';
+import 'package:school_planting/core/data/clients/supabase/supabase_client_interface.dart';
+import 'package:school_planting/shared/components/app_circular_indicator_widget.dart';
+import 'package:school_planting/shared/components/custom_app_bar.dart';
+import 'package:school_planting/shared/themes/app_theme_constants.dart';
+
+import '../domain/usecases/get_impact_usecase.dart';
+import '../data/repositories/impact_repository_impl.dart';
+import '../data/datasources/impact_datasource_impl.dart';
+import 'controller/impact_bloc.dart';
+import 'controller/impact_events.dart';
+import 'controller/impact_states.dart';
+
+class ImpactPage extends StatefulWidget {
+  const ImpactPage({super.key});
+
+  @override
+  State<ImpactPage> createState() => _ImpactPageState();
+}
+
+class _ImpactPageState extends State<ImpactPage> {
+  late final ImpactBloc _bloc;
+
+  @override
+  void initState() {
+    super.initState();
+    _bloc = ImpactBloc(
+      usecase: GetImpactUseCase(
+        repository: ImpactRepositoryImpl(
+          datasource: ImpactDatasourceImpl(
+            supabaseClient: getIt<ISupabaseClient>(),
+          ),
+        ),
+      ),
+    );
+    _bloc.add(LoadImpactEvent());
+  }
+
+  @override
+  void dispose() {
+    _bloc.close();
+    super.dispose();
+  }
+
+  Widget _buildItem(String label, String value, IconData icon) {
+    return Card(
+      margin: const EdgeInsets.symmetric(vertical: 8),
+      child: ListTile(
+        leading: Icon(icon),
+        title: Text(label),
+        trailing: Text(value),
+      ),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: CustomAppBar(title: const Text('Impacto Ambiental')),
+      body: SafeArea(
+        child: BlocBuilder<ImpactBloc, ImpactStates>(
+          bloc: _bloc,
+          builder: (context, state) {
+            if (state is ImpactLoadingState) {
+              return const Center(child: AppCircularIndicatorWidget());
+            }
+            if (state is ImpactSuccessState) {
+              final m = state.metrics;
+              return Padding(
+                padding: const EdgeInsets.all(AppThemeConstants.padding),
+                child: Column(
+                  children: [
+                    _buildItem('Oxig\u00eanio gerado', m.oxygen.toStringAsFixed(1), Icons.air),
+                    _buildItem('Carbono sequestrado (CO\u2082)', m.carbon.toStringAsFixed(1), Icons.co2),
+                    _buildItem('Redu\u00e7\u00e3o de temperatura', m.temperature.toStringAsFixed(1), Icons.thermostat),
+                    _buildItem('Reten\u00e7\u00e3o de \u00e1gua e solo', m.water.toStringAsFixed(1), Icons.water_drop),
+                    _buildItem('Biodiversidade', m.biodiversity.toStringAsFixed(1), Icons.bug_report),
+                    _buildItem('Melhoria na qualidade do ar', m.airQuality.toStringAsFixed(1), Icons.air_outlined),
+                  ],
+                ),
+              );
+            }
+            if (state is ImpactFailureState) {
+              return Center(child: Text(state.message));
+            }
+            return const SizedBox.shrink();
+          },
+        ),
+      ),
+    );
+  }
+}

--- a/test/helpers/mocks.dart
+++ b/test/helpers/mocks.dart
@@ -8,6 +8,8 @@ import 'package:school_planting/modules/my_plantings/data/datasources/my_plantin
 import 'package:school_planting/modules/my_plantings/domain/repositories/my_plantings_repository.dart';
 import 'package:school_planting/modules/planting/data/datasources/planting_datasource.dart';
 import 'package:school_planting/modules/planting/domain/repositories/planting_repository.dart';
+import 'package:school_planting/modules/impact/data/datasources/impact_datasource.dart';
+import 'package:school_planting/modules/impact/domain/repositories/impact_repository.dart';
 import 'package:supabase_flutter/supabase_flutter.dart';
 
 class MockAuthRepository extends Mock implements AuthRepository {}
@@ -20,3 +22,5 @@ class MockMyPlantingsDatasource extends Mock implements MyPlantingsDatasource {}
 class MockPlantingRepository extends Mock implements PlantingRepository {}
 class MockPlantingDatasource extends Mock implements PlantingDatasource {}
 class MockSupabaseUser extends Mock implements User {}
+class MockImpactDatasource extends Mock implements ImpactDatasource {}
+class MockImpactRepository extends Mock implements ImpactRepository {}

--- a/test/unit/impact/get_impact_usecase_test.dart
+++ b/test/unit/impact/get_impact_usecase_test.dart
@@ -1,0 +1,30 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:school_planting/core/domain/entities/either_of.dart';
+import 'package:school_planting/core/domain/entities/usecase.dart';
+import 'package:school_planting/modules/impact/domain/entities/impact_entity.dart';
+import 'package:school_planting/modules/impact/domain/usecases/get_impact_usecase.dart';
+
+import '../../helpers/mocks.dart';
+import 'package:mockito/mockito.dart';
+
+void main() {
+  group('GetImpactUseCase', () {
+    late MockImpactRepository repository;
+    late GetImpactUseCase usecase;
+
+    setUp(() {
+      repository = MockImpactRepository();
+      usecase = GetImpactUseCase(repository: repository);
+    });
+
+    test('calls repository to get impact', () async {
+      when(repository.getImpactData())
+          .thenAnswer((_) async => resolve(ImpactEntity.fromCount(1)));
+
+      final result = await usecase(const NoArgs());
+
+      verify(repository.getImpactData()).called(1);
+      expect(result.isRight, true);
+    });
+  });
+}

--- a/test/unit/impact/impact_datasource_impl_test.dart
+++ b/test/unit/impact/impact_datasource_impl_test.dart
@@ -1,0 +1,38 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mockito/mockito.dart';
+import 'package:school_planting/modules/impact/data/datasources/impact_datasource_impl.dart';
+
+import '../../helpers/mocks.dart';
+
+void main() {
+  group('ImpactDatasourceImpl', () {
+    late MockISupabaseClient client;
+    late ImpactDatasourceImpl datasource;
+
+    setUp(() {
+      client = MockISupabaseClient();
+      datasource = ImpactDatasourceImpl(supabaseClient: client);
+    });
+
+    test('countPlantings returns length', () async {
+      when(
+        client.select(
+          table: 'user_plantings',
+          columns: 'id',
+          filters: {'user_id': '1'},
+        ),
+      ).thenAnswer((_) async => [1, 2, 3]);
+
+      final result = await datasource.countPlantings('1');
+
+      expect(result, 3);
+      verify(
+        client.select(
+          table: 'user_plantings',
+          columns: 'id',
+          filters: {'user_id': '1'},
+        ),
+      ).called(1);
+    });
+  });
+}

--- a/test/unit/impact/impact_repository_impl_test.dart
+++ b/test/unit/impact/impact_repository_impl_test.dart
@@ -1,0 +1,30 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mockito/mockito.dart';
+import 'package:school_planting/core/domain/entities/app_global.dart';
+import 'package:school_planting/modules/auth/domain/entities/user_entity.dart';
+import 'package:school_planting/modules/impact/data/repositories/impact_repository_impl.dart';
+import 'package:school_planting/modules/impact/domain/repositories/impact_repository.dart';
+
+import '../../helpers/mocks.dart';
+
+void main() {
+  group('ImpactRepositoryImpl', () {
+    late MockImpactDatasource datasource;
+    late ImpactRepository repository;
+
+    setUp(() {
+      datasource = MockImpactDatasource();
+      repository = ImpactRepositoryImpl(datasource: datasource);
+      AppGlobal(user: UserEntity(id: '1', email: '', name: ''));
+    });
+
+    test('returns metrics on success', () async {
+      when(datasource.countPlantings('1')).thenAnswer((_) async => 2);
+
+      final result = await repository.getImpactData();
+
+      verify(datasource.countPlantings('1')).called(1);
+      expect(result.isRight, true);
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- add Environmental Impact module following project structure
- compute metrics from number of plantings
- display totals on new ImpactPage
- expose ImpactPage through routes and user card button
- extend mocks and unit tests for the new module

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686f1b0854f48322bbb72955476cd9c2