### PR TITLE
Improve environmental impact page

### DIFF
--- a/lib/modules/impact/domain/entities/impact_entity.dart
+++ b/lib/modules/impact/domain/entities/impact_entity.dart
@@ -5,6 +5,7 @@ class ImpactEntity {
   final double water;
   final double biodiversity;
   final double airQuality;
+  final int totalPlantings;
 
   ImpactEntity({
     required this.oxygen,
@@ -13,6 +14,7 @@ class ImpactEntity {
     required this.water,
     required this.biodiversity,
     required this.airQuality,
+    required this.totalPlantings,
   });
 
   factory ImpactEntity.fromCount(int count) {
@@ -30,6 +32,7 @@ class ImpactEntity {
       water: waterPerPlant * count,
       biodiversity: biodiversityPerPlant * count,
       airQuality: airQualityPerPlant * count,
+      totalPlantings: count,
     );
   }
 }

--- a/lib/modules/impact/presentation/impact_page.dart
+++ b/lib/modules/impact/presentation/impact_page.dart
@@ -43,6 +43,25 @@ class _ImpactPageState extends State<ImpactPage> {
     );
   }
 
+  Widget _buildSummary(int count) {
+    final String text =
+        'Você já realizou $count ${count == 1 ? 'plantação' : 'plantações'}!';
+    return Card(
+      margin: const EdgeInsets.only(bottom: AppThemeConstants.padding),
+      child: Padding(
+        padding: const EdgeInsets.all(AppThemeConstants.mediumPadding),
+        child: Text(
+          text,
+          textAlign: TextAlign.center,
+          style: Theme.of(context).textTheme.titleMedium?.copyWith(
+                fontWeight: FontWeight.bold,
+              ),
+        ),
+      ),
+    );
+  }
+
+
   @override
   Widget build(BuildContext context) {
     return Scaffold(
@@ -60,6 +79,7 @@ class _ImpactPageState extends State<ImpactPage> {
                 padding: const EdgeInsets.all(AppThemeConstants.padding),
                 child: Column(
                   children: [
+                      _buildSummary(m.totalPlantings),
                     _buildItem(
                       'Oxigênio gerado',
                       m.oxygen.toStringAsFixed(1),

--- a/test/unit/impact/get_impact_usecase_test.dart
+++ b/test/unit/impact/get_impact_usecase_test.dart
@@ -25,6 +25,10 @@ void main() {
 
       verify(repository.getImpactData()).called(1);
       expect(result.isRight, true);
+      result.get((_) => null, (data) {
+        expect(data.totalPlantings, 1);
+        return null;
+      });
     });
   });
 }

--- a/test/unit/impact/impact_repository_impl_test.dart
+++ b/test/unit/impact/impact_repository_impl_test.dart
@@ -25,6 +25,10 @@ void main() {
 
       verify(datasource.countPlantings('1')).called(1);
       expect(result.isRight, true);
+      result.get((_) => null, (data) {
+        expect(data.totalPlantings, 2);
+        return null;
+      });
     });
   });
 }


### PR DESCRIPTION
## Summary
- track the total number of plantings
- display the planting count on the impact page
- check planting count in unit tests

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686f1f71cfc88322a7caec095edb175c