### PR TITLE
Improve impact page UI

### DIFF
--- a/lib/modules/impact/presentation/impact_page.dart
+++ b/lib/modules/impact/presentation/impact_page.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:lottie/lottie.dart';
 import 'package:school_planting/core/di/dependency_injection.dart';
 import 'package:school_planting/shared/components/app_circular_indicator_widget.dart';
 import 'package:school_planting/shared/components/custom_app_bar.dart';
@@ -26,21 +27,58 @@ class _ImpactPageState extends State<ImpactPage> {
     _impactBloc.add(LoadImpactEvent());
   }
 
+  Widget _buildHeader() {
+    return Lottie.asset(
+      'assets/lotties/success.json',
+      height: 120,
+      repeat: false,
+    );
+  }
+
   @override
   void dispose() {
     _impactBloc.close();
     super.dispose();
   }
 
-  Widget _buildItem(String label, String value, IconData icon) {
+  Widget _buildItem(
+    String label,
+    String value,
+    IconData icon, {
+    Color? color,
+    String? description,
+  }) {
+    final background = color?.withOpacity(0.15);
     return Card(
+      color: background,
       margin: const EdgeInsets.symmetric(vertical: 8),
-      child: ListTile(
-        leading: Icon(icon),
-        title: Text(label),
-        trailing: Text(
-          value,
-          style: const TextStyle(fontWeight: FontWeight.bold),
+      child: Padding(
+        padding: const EdgeInsets.all(AppThemeConstants.mediumPadding),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Row(
+              children: [
+                Icon(icon, color: color),
+                const SizedBox(width: AppThemeConstants.mediumPadding),
+                Expanded(child: Text(label)),
+                Text(
+                  value,
+                  style: Theme.of(context).textTheme.titleMedium?.copyWith(
+                        fontWeight: FontWeight.bold,
+                      ),
+                ),
+              ],
+            ),
+            if (description != null)
+              Padding(
+                padding: const EdgeInsets.only(top: 4.0),
+                child: Text(
+                  description,
+                  style: Theme.of(context).textTheme.bodySmall,
+                ),
+              ),
+          ],
         ),
       ),
     );
@@ -78,20 +116,28 @@ class _ImpactPageState extends State<ImpactPage> {
             }
             if (state is ImpactSuccessState) {
               final m = state.metrics;
+              final oxygenPeople = (m.oxygen / 240).round();
+              final avoidedKm = (m.carbon * 350 / 88).round();
+              final waterTanks = (m.water / 200).round();
               return Padding(
                 padding: const EdgeInsets.all(AppThemeConstants.padding),
                 child: Column(
                   children: [
-                      _buildSummary(m.totalPlantings),
+                    _buildHeader(),
+                    _buildSummary(m.totalPlantings),
                     _buildItem(
                       'Oxigênio gerado',
                       '${m.oxygen.toStringAsFixed(1)} kg/ano',
                       Icons.air,
+                      color: Colors.green,
+                      description:
+                          'Oxigênio para $oxygenPeople pessoas por 2 anos',
                     ),
                     _buildItem(
                       'Carbono capturado (CO₂)',
                       '${m.carbon.toStringAsFixed(1)} kg/ano',
                       Icons.co2,
+                      description: '$avoidedKm km de carro evitados',
                     ),
                     _buildItem(
                       'Redução de temperatura',
@@ -102,11 +148,15 @@ class _ImpactPageState extends State<ImpactPage> {
                       'Retenção de água e solo',
                       '${m.water.toStringAsFixed(1)} L/ano',
                       Icons.water_drop,
+                      color: Colors.blue,
+                      description:
+                          '$waterTanks caixa(s) d\'água de reserva',
                     ),
                     _buildItem(
                       'Biodiversidade (ex: abelhas e polinizadores)',
                       '${m.biodiversity.toStringAsFixed(1)} pts',
                       Icons.bug_report,
+                      color: Colors.orange,
                     ),
                     _buildItem(
                       'Melhoria na qualidade do ar',


### PR DESCRIPTION
## Summary
- show success animation on environmental impact screen
- highlight metric cards with colors and bigger fonts
- show textual equivalence for oxygen, carbon and water metrics

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686f27a334cc8322bdc0f0ecf10ed5e0