### PR TITLE
Add custom transition for processing page

### DIFF
--- a/lib/modules/planting/presentation/planting_page.dart
+++ b/lib/modules/planting/presentation/planting_page.dart
@@ -31,6 +31,7 @@ class _PlantingPageState extends State<PlantingPage> {
   final ImagePicker _picker = ImagePicker();
   File? _image;
   final GlobalKey<FormState> _formKey = GlobalKey<FormState>();
+  final GlobalKey _saveButtonKey = GlobalKey();
 
   @override
   void initState() {
@@ -99,10 +100,28 @@ class _PlantingPageState extends State<PlantingPage> {
 
     if (!mounted) return;
 
+    final RenderBox box =
+        _saveButtonKey.currentContext!.findRenderObject() as RenderBox;
+    final Offset position = box.localToGlobal(box.size.center(Offset.zero));
+    final Size screen = MediaQuery.of(context).size;
+    final Alignment alignment = Alignment(
+      (position.dx / screen.width) * 2 - 1,
+      (position.dy / screen.height) * 2 - 1,
+    );
+
     final result = await Navigator.push<bool>(
       context,
-      MaterialPageRoute(
-        builder: (_) => ProcessingPage(entity: entity, image: _image!),
+      PageRouteBuilder(
+        transitionDuration: const Duration(milliseconds: 500),
+        pageBuilder: (_, __, ___) => ProcessingPage(entity: entity, image: _image!),
+        transitionsBuilder: (_, animation, __, child) {
+          final curved = CurvedAnimation(parent: animation, curve: Curves.easeOutCubic);
+          return ScaleTransition(
+            scale: curved,
+            alignment: alignment,
+            child: child,
+          );
+        },
       ),
     );
 
@@ -143,6 +162,7 @@ class _PlantingPageState extends State<PlantingPage> {
           children: [
             Divider(),
             AppCustomButton(
+              buttonKey: _saveButtonKey,
               expands: true,
               onPressed: _save,
               label: _buildButtonLabel(),

--- a/lib/shared/components/custom_button.dart
+++ b/lib/shared/components/custom_button.dart
@@ -11,6 +11,7 @@ class AppCustomButton extends StatelessWidget {
   final Function()? onPressed;
   final bool expands;
   final double height;
+  final Key? buttonKey;
   Color? backgroundColor;
   double radius;
 
@@ -21,6 +22,7 @@ class AppCustomButton extends StatelessWidget {
     required this.onPressed,
     this.expands = false,
     this.height = 40,
+    this.buttonKey,
     this.backgroundColor,
     this.radius = AppThemeConstants.mediumBorderRadius,
   });
@@ -31,6 +33,7 @@ class AppCustomButton extends StatelessWidget {
 
     return icon != null
         ? ElevatedButton.icon(
+            key: buttonKey,
             onPressed: onPressed,
             style: ElevatedButton.styleFrom(
               backgroundColor: backgroundColor,
@@ -46,6 +49,7 @@ class AppCustomButton extends StatelessWidget {
             label: label,
           )
         : ElevatedButton(
+            key: buttonKey,
             onPressed: onPressed,
             style: ElevatedButton.styleFrom(
               backgroundColor: backgroundColor,


### PR DESCRIPTION
## Summary
- allow AppCustomButton to expose its key
- animate ProcessingPage as a scale transition starting from the save button

## Testing
- `flutter format lib/shared/components/custom_button.dart lib/modules/planting/presentation/planting_page.dart` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686f488bdc788322b1672467e2921e9a