### PR TITLE
Return to home after successful image upload

### DIFF
--- a/lib/modules/planting/presentation/planting_page.dart
+++ b/lib/modules/planting/presentation/planting_page.dart
@@ -113,7 +113,7 @@ class _PlantingPageState extends State<PlantingPage> {
 
     if (!mounted) return;
 
-    await Navigator.push(
+    final bool? result = await Navigator.push(
       context,
       PageRouteBuilder(
         pageBuilder: (_, __, ___) => ProcessingPage(
@@ -128,6 +128,12 @@ class _PlantingPageState extends State<PlantingPage> {
     );
 
     setState(() => isExpanding = false);
+
+    if (!mounted) return;
+
+    if (result == true) {
+      Navigator.pop(context);
+    }
   }
 
   Widget _buildButtonLabel() {


### PR DESCRIPTION
## Summary
- ensure PlantingPage exits to previous screen after a successful upload

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687005d319ac8322b411b5d089f7e02a