### PR TITLE
Fix iOS Google Maps configuration

### DIFF
--- a/ios/Runner/Info.plist
+++ b/ios/Runner/Info.plist
@@ -43,7 +43,15 @@
 	</array>
 	<key>CADisableMinimumFrameDurationOnPhone</key>
 	<true/>
-	<key>UIApplicationSupportsIndirectInputEvents</key>
-	<true/>
+        <key>UIApplicationSupportsIndirectInputEvents</key>
+        <true/>
+        <key>io.flutter.embedded_views_preview</key>
+        <true/>
+        <key>GMSApiKey</key>
+        <string>AIzaSyDWniSNLdzYdNqJNlVHRXz9TqLDDwytkNo</string>
+        <key>NSLocationWhenInUseUsageDescription</key>
+        <string>This app needs access to your location to show your position on the map.</string>
+        <key>NSLocationAlwaysAndWhenInUseUsageDescription</key>
+        <string>This app needs access to your location to show your position on the map.</string>
 </dict>
 </plist>


### PR DESCRIPTION
## Summary
- add missing Google Maps and location configuration to Info.plist

## Testing
- `flutter --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688816daa35c832285aea560b3b16b2a