### PR TITLE
Improve login button feedback

### DIFF
--- a/lib/modules/auth/presentation/auth_page.dart
+++ b/lib/modules/auth/presentation/auth_page.dart
@@ -53,11 +53,13 @@ class _AuthPageState extends State<AuthPage> {
   }
 
   Widget _handleButtonGoogle(AuthStates states) {
-    if (states is AuthLoadingState) {
+    if (states is AuthLoadingState &&
+        states.provider == AuthProvider.google) {
       return const AppCircularIndicatorWidget(size: 20);
     }
 
-    if (states is AuthSuccessState) {
+    if (states is AuthSuccessState &&
+        states.provider == AuthProvider.google) {
       return const Icon(Icons.check, color: Colors.white, size: 25);
     }
 
@@ -68,11 +70,12 @@ class _AuthPageState extends State<AuthPage> {
   }
 
   Widget _handleButtonApple(AuthStates states) {
-    if (states is AuthLoadingState) {
+    if (states is AuthLoadingState && states.provider == AuthProvider.apple) {
       return const AppCircularIndicatorWidget(size: 20);
     }
 
-    if (states is AuthSuccessState) {
+    if (states is AuthSuccessState &&
+        states.provider == AuthProvider.apple) {
       return const Icon(Icons.check, color: Colors.black, size: 25);
     }
 
@@ -157,11 +160,12 @@ class _AuthPageState extends State<AuthPage> {
                           onPressed: () {
                             _authBloc.add(LoginWithGoogleAccountEvent());
                           },
-                          icon:
-                              state is! AuthLoadingState &&
-                                  state is! AuthSuccessState
-                              ? Image.asset(AppAssets.google, width: 25)
-                              : null,
+                          icon: (state is AuthLoadingState &&
+                                      state.provider == AuthProvider.google) ||
+                                  (state is AuthSuccessState &&
+                                      state.provider == AuthProvider.google)
+                              ? null
+                              : Image.asset(AppAssets.google, width: 25),
                           label: _handleButtonGoogle(state),
                         );
                       },
@@ -185,11 +189,12 @@ class _AuthPageState extends State<AuthPage> {
                           onPressed: () {
                             _authBloc.add(LoginWithAppleAccountEvent());
                           },
-                          icon:
-                              state is! AuthLoadingState &&
-                                  state is! AuthSuccessState
-                              ? Image.asset(AppAssets.apple, width: 25)
-                              : null,
+                          icon: (state is AuthLoadingState &&
+                                      state.provider == AuthProvider.apple) ||
+                                  (state is AuthSuccessState &&
+                                      state.provider == AuthProvider.apple)
+                              ? null
+                              : Image.asset(AppAssets.apple, width: 25),
                           label: _handleButtonApple(state),
                         );
                       },

--- a/lib/modules/auth/presentation/controller/auth_bloc.dart
+++ b/lib/modules/auth/presentation/controller/auth_bloc.dart
@@ -30,13 +30,13 @@ class AuthBloc extends Bloc<AuthEvents, AuthStates> {
     LoginWithGoogleAccountEvent event,
     Emitter<AuthStates> emit,
   ) async {
-    emit(state.loading());
+    emit(state.loading(AuthProvider.google));
 
     final result = await _loginWithGoogleAccountUseCase(NoArgs());
 
     result.get(
       (failure) => emit(state.failure(failure.message)),
-      (user) => emit(state.success(user)),
+      (user) => emit(state.success(user, AuthProvider.google)),
     );
   }
 
@@ -44,13 +44,13 @@ class AuthBloc extends Bloc<AuthEvents, AuthStates> {
     LoginWithAppleAccountEvent event,
     Emitter<AuthStates> emit,
   ) async {
-    emit(state.loading());
+    emit(state.loading(AuthProvider.apple));
 
     final result = await _loginWithAppleAccountUseCase(NoArgs());
 
     result.get(
       (failure) => emit(state.failure(failure.message)),
-      (user) => emit(state.success(user)),
+      (user) => emit(state.success(user, AuthProvider.apple)),
     );
   }
 
@@ -58,7 +58,7 @@ class AuthBloc extends Bloc<AuthEvents, AuthStates> {
     LogoutAccountEvent event,
     Emitter<AuthStates> emit,
   ) async {
-    emit(state.loading());
+    emit(state.loading(AuthProvider.google));
 
     await Future.delayed(const Duration(seconds: 1));
 

--- a/lib/modules/auth/presentation/controller/auth_states.dart
+++ b/lib/modules/auth/presentation/controller/auth_states.dart
@@ -1,10 +1,13 @@
 // ignore_for_file: public_member_api_docs, sort_constructors_first
 import 'package:school_planting/modules/auth/domain/entities/user_entity.dart';
 
-abstract class AuthStates {
-  AuthLoadingState loading() => AuthLoadingState();
+enum AuthProvider { google, apple }
 
-  AuthSuccessState success(UserEntity user) => AuthSuccessState(user: user);
+abstract class AuthStates {
+  AuthLoadingState loading(AuthProvider provider) => AuthLoadingState(provider);
+
+  AuthSuccessState success(UserEntity user, AuthProvider provider) =>
+      AuthSuccessState(user: user, provider: provider);
 
   AuthFailureState failure(String message) => AuthFailureState(message);
 
@@ -13,12 +16,17 @@ abstract class AuthStates {
 
 class AuthInitialState extends AuthStates {}
 
-class AuthLoadingState extends AuthStates {}
+class AuthLoadingState extends AuthStates {
+  final AuthProvider provider;
+
+  AuthLoadingState(this.provider);
+}
 
 class AuthSuccessState extends AuthStates {
-  UserEntity user;
+  final UserEntity user;
+  final AuthProvider provider;
 
-  AuthSuccessState({required this.user});
+  AuthSuccessState({required this.user, required this.provider});
 }
 
 class AuthFailureState extends AuthStates {


### PR DESCRIPTION
## Summary
- show progress & success indicator only on pressed login button
- add provider info to auth states

## Testing
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688aba16f7fc8322ab93beaddf106b87